### PR TITLE
Fix usa bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.0.1 (2024-11-10)
+Fixes a bug with non-USD constant figures.
+
 ## v2.0.0 (2024-11-10)
 
 🚀 Major Release

--- a/pydeflate/core/exchange.py
+++ b/pydeflate/core/exchange.py
@@ -37,6 +37,8 @@ class Exchange:
             self.exchange_data = self.exchange_rate(
                 self.source_currency, self.target_currency
             )
+            if self.source_currency == "USA":
+                self.exchange_data["pydeflate_EXCHANGE_D"] = 1
 
     def _get_exchange_rate(self, currency):
         """Helper function to fetch exchange rates for a given currency."""

--- a/tests/test_dac_deflator.py
+++ b/tests/test_dac_deflator.py
@@ -52,6 +52,36 @@ def test_to_constant(tolerance=0.01):
     )
 
 
+def test_to_constant_lcu_USA(tolerance=0.01):
+
+    # Perform the deflation calculation
+    test_df = oecd_dac_deflate(
+        data=df,
+        base_year=2022,
+        source_currency="LCU",
+        target_currency="USA",
+        id_column="donor_code",
+        use_source_codes=True,
+        value_column="N",
+    )
+
+    # Calculate the percentage deviation
+    deviations = abs((test_df["value"] - test_df["D"]) / test_df["D"])
+
+    # Filter out rows where D is NaN to avoid unnecessary comparisons
+    mask = test_df["D"].notna() & (deviations >= tolerance)
+    failing_rows = test_df[mask]
+
+    failing_rows = failing_rows.loc[lambda d: d.donor_code < 20000]
+
+    # Assert that no rows exceed the tolerance
+    assert failing_rows.empty, (
+        f"Deviation exceeded {tolerance*100:.2f}% in the following"
+        f"donors:\n"
+        f"{failing_rows.donor_code.unique()}"
+    )
+
+
 def test_to_current(tolerance=0.01):
 
     # Perform the adjustment to current currency


### PR DESCRIPTION
This pull request includes several changes to fix a bug related to non-USD constant figures and to add new test coverage for this scenario.

Bug Fix:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5): Added an entry for version 2.0.1, noting the fix for a bug with non-USD constant figures.

Code Updates:
* [`pydeflate/core/exchange.py`](diffhunk://#diff-ac3f00df9334823d3bcfbf5b8c2e3a13b6724be6f63fbb99f0a906cd22337da2R40-R41): Added a condition to set `pydeflate_EXCHANGE_D` to 1 when the source currency is "USA".

Testing Enhancements:
* [`tests/test_dac_deflator.py`](diffhunk://#diff-c1592b3c8ddedf07b83aa1ef08e59b582f3dc562073fe0463d89420bf3f960a1R55-R84): Added a new test function `test_to_constant_lcu_USA` to ensure the deflation calculation for local currency units (LCU) to USD is accurate and within tolerance.