### PR TITLE
16 dac eu institutions non usd non eur constant

### DIFF
--- a/pydeflate/core/exchange.py
+++ b/pydeflate/core/exchange.py
@@ -37,8 +37,6 @@ class Exchange:
             self.exchange_data = self.exchange_rate(
                 self.source_currency, self.target_currency
             )
-            if self.source_currency == "USA":
-                self.exchange_data["pydeflate_EXCHANGE_D"] = 1
 
     def _get_exchange_rate(self, currency):
         """Helper function to fetch exchange rates for a given currency."""

--- a/tests/test_dac_totals.py
+++ b/tests/test_dac_totals.py
@@ -33,7 +33,7 @@ data_eur = {
     "donor_code": [742] * 4,
     "currency": ["EUR"] * 4,
     "prices": ["current"] * 4,
-    "value": [1974, 2429, 2672, 2986],
+    "value": [1974, 2429, 2672, 2896],
     "expected_value": [1995, 2403, 2619, 2896],
 }
 df_eur = pd.DataFrame(data_eur)
@@ -61,6 +61,30 @@ data_lcu = {
     "expected_value": [13625, 14210, 16031, 14266],
 }
 df_lcu = pd.DataFrame(data_lcu)
+
+data_eui_gbp = {
+    "year": [2020, 2021, 2022, 2023],
+    "indicator": ["total_oda_official_definition"] * 4,
+    "donor_code": [918] * 4,
+    "currency": ["USD"] * 4,
+    "prices": ["current"] * 4,
+    "value": [19568, 19054, 22534, 26926],
+    "expected_value": [16882, 15490, 19693, 21662],
+}
+
+df_eui_gbp = pd.DataFrame(data_eui_gbp)
+
+data_aus_gbp = {
+    "year": [2020, 2021, 2022, 2023],
+    "indicator": ["total_oda_official_definition"] * 4,
+    "donor_code": [801] * 4,
+    "currency": ["USD"] * 4,
+    "prices": ["current"] * 4,
+    "value": [2869, 3546, 3046, 3253],
+    "expected_value": [2629, 2822, 2432, 2617],
+}
+
+df_aus_gbp = pd.DataFrame(data_aus_gbp)
 
 
 def run_constant_test(
@@ -130,17 +154,29 @@ def test_to_constant_usd():
 
 def test_to_constant_eur():
     run_constant_test(
-        data=df_eur, source_currency="EUR", target_currency="EUR", tolerance=0.05
+        data=df_eur, source_currency="EUR", target_currency="EUR", tolerance=0.02
     )
 
 
 def test_to_constant_can():
     run_constant_test(
-        data=df_can, source_currency="CAN", target_currency="USA", tolerance=0.05
+        data=df_can, source_currency="CAN", target_currency="USA", tolerance=0.02
     )
 
 
 def test_to_constant_lcu():
     run_constant_test(
-        data=df_lcu, source_currency="EUR", target_currency="LCU", tolerance=0.05
+        data=df_lcu, source_currency="EUR", target_currency="LCU", tolerance=0.02
+    )
+
+
+def test_eui_gbp_constant():
+    run_constant_test(
+        data=df_eui_gbp, source_currency="USD", target_currency="GBP", tolerance=0.02
+    )
+
+
+def test_aus_gbp_constant():
+    run_constant_test(
+        data=df_aus_gbp, source_currency="USD", target_currency="GBP", tolerance=0.02
     )


### PR DESCRIPTION
This pull request includes changes to the `pydeflate` core exchange functionality and updates to the `tests/test_dac_totals.py` test file. The most important changes include removing a specific condition in the exchange rate calculation, updating test data values, and adding new test cases.

Core exchange functionality:

* [`pydeflate/core/exchange.py`](diffhunk://#diff-ac3f00df9334823d3bcfbf5b8c2e3a13b6724be6f63fbb99f0a906cd22337da2L40-L41): Removed the condition that set `pydeflate_EXCHANGE_D` to 1 when the source currency is "USA".

Updates to test data:

* [`tests/test_dac_totals.py`](diffhunk://#diff-d3a6c29f954dfd5b8f6a963155366976432872fc5e6bb1cc837f5f74c782507aL36-R36): Updated the `value` and `expected_value` fields in the `data_eur` test data.

New test cases:

* [`tests/test_dac_totals.py`](diffhunk://#diff-d3a6c29f954dfd5b8f6a963155366976432872fc5e6bb1cc837f5f74c782507aR65-R88): Added new test data for `data_eui_gbp` and `data_aus_gbp`, including their respective DataFrame definitions.
* [`tests/test_dac_totals.py`](diffhunk://#diff-d3a6c29f954dfd5b8f6a963155366976432872fc5e6bb1cc837f5f74c782507aL133-R181): Added new test cases `test_eui_gbp_constant` and `test_aus_gbp_constant` to run constant tests on the new test data.

Tolerance adjustments:

* [`tests/test_dac_totals.py`](diffhunk://#diff-d3a6c29f954dfd5b8f6a963155366976432872fc5e6bb1cc837f5f74c782507aL133-R181): Adjusted the tolerance parameter from 0.05 to 0.02 in existing test cases `test_to_constant_eur`, `test_to_constant_can`, and `test_to_constant_lcu`.