### PR TITLE
Fill dac gaps

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.1.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.1.1(2025-02-21)
+In DAC statistics, the DAC deflators are used for entities which do not have their
+own DAC deflator. This patch enforces that behaviour.
+
 ## v2.1 (2024-11-18)
 **New feature**: added a tool to convert numbers to current PPP, using
 World Bank data.

--- a/pydeflate/__init__.py
+++ b/pydeflate/__init__.py
@@ -1,5 +1,5 @@
 __author__ = """Jorge Rivera"""
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 from pydeflate.deflate.deflators import (
     oecd_dac_deflate,

--- a/pydeflate/core/api.py
+++ b/pydeflate/core/api.py
@@ -176,6 +176,8 @@ class BaseExchange:
             pydeflate_data=self.pydeflate_data,
             entity_column=entity_column,
             ix=self._idx,
+            source_codes=self._idx[-1] == "pydeflate_entity_code",
+            dac=self.exchange_rates.source.name == "DAC",
         )
 
         # store unmatched data
@@ -365,6 +367,9 @@ class BaseDeflate:
             pydeflate_data=self.pydeflate_data,
             entity_column=entity_column,
             ix=self._idx,
+            source_codes=self.use_source_codes,
+            dac=self.exchange_deflator.source.name == "DAC"
+            or self.price_deflator.source.name == "DAC",
         )
 
         # store unmatched data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydeflate"
-version = "2.1.0"
+version = "2.1.1"
 description = "Package to convert current prices figures to constant prices and vice versa"
 authors = ["Jorge Rivera <jorge.rivera@one.org>"]
 license = "MIT"


### PR DESCRIPTION
This PR adds functionality for handling DAC deflators when data is missing.

Version update and changelog:

New functionality for handling DAC deflators:

* [`pydeflate/utils.py`](diffhunk://#diff-7485a87d7122b5aaee68ba17287515e957e229546661b98d7dd2814497de0c4bR54-R115): Added `_use_implied_dac_rates` function to use DAC overall rates when rates are missing for entities in DAC data.

Modifications to existing functions:

* [`pydeflate/core/api.py`](diffhunk://#diff-687dcfe0235d16f3171b725f8748ab77be5d572bbf044e9ce81eb51bfea22e11R179-R180): Updated `_merge_pydeflate_data` function to include `source_codes` and `dac` parameters. [[1]](diffhunk://#diff-687dcfe0235d16f3171b725f8748ab77be5d572bbf044e9ce81eb51bfea22e11R179-R180) [[2]](diffhunk://#diff-687dcfe0235d16f3171b725f8748ab77be5d572bbf044e9ce81eb51bfea22e11R370-R372)
* [`pydeflate/utils.py`](diffhunk://#diff-7485a87d7122b5aaee68ba17287515e957e229546661b98d7dd2814497de0c4bR54-R115): Modified `merge_user_and_pydeflate_data` to use `_use_implied_dac_rates` when `dac` is `True`.
* [`pydeflate/utils.py`](diffhunk://#diff-7485a87d7122b5aaee68ba17287515e957e229546661b98d7dd2814497de0c4bL89-R139): Updated `flag_missing_pydeflate_data` to log messages differently when using implied DAC rates. [[1]](diffhunk://#diff-7485a87d7122b5aaee68ba17287515e957e229546661b98d7dd2814497de0c4bL89-R139) [[2]](diffhunk://#diff-7485a87d7122b5aaee68ba17287515e957e229546661b98d7dd2814497de0c4bL105-R160)