### PR TITLE
Add `get` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented in this file. The format foll
 
 ## [Unreleased]
 
+## [2.3.0] - 2025-10-05
+### Added
+- **Get Deflators Functions**: New functions to retrieve deflator data directly as DataFrames without requiring user data:
+  - `get_imf_gdp_deflators()`, `get_imf_cpi_deflators()`, `get_imf_cpi_e_deflators()`
+  - `get_wb_gdp_deflators()`, `get_wb_gdp_linked_deflators()`, `get_wb_cpi_deflators()`
+  - `get_oecd_dac_deflators()`
+- **Get Exchange Rates Functions**: New functions to retrieve exchange rate data directly as DataFrames:
+  - `get_imf_exchange_rates()`, `get_wb_exchange_rates()`
+  - `get_wb_ppp_rates()`, `get_oecd_dac_exchange_rates()`
+- **Flexible Filtering**: All new functions support optional filtering by countries and years via `countries` and `years` parameters.
+- **Component Breakdown**: `include_components=True` parameter for deflator functions to retrieve price deflator, exchange deflator, and exchange rate components separately for analysis.
+
+### Changed
+- Documentation: Updated README.md with extensive examples of the new get deflator and exchange rate functions.
+- Documentation: Added new section "Getting Deflators and Exchange Rates Directly" with common use cases.
+
+### Use Cases
+The new functions enable:
+- Inspecting and analyzing deflator trends over time
+- Pre-computing deflators for custom calculations
+- Understanding the components that make up deflators
+- Retrieving exchange rates for analysis without converting data
+
 ## [2.2.0] - 2025-10-05
 ### Added
 - **Plugin Architecture**: Register custom data sources without modifying pydeflate code via `register_source()`, `get_source()`, `list_sources()`, and `is_source_registered()`.

--- a/DOCS.md
+++ b/DOCS.md
@@ -12,7 +12,7 @@ pydeflate uses [Material for MkDocs](https://squidfunk.github.io/mkdocs-material
 docs/
 ├── index.md                    # Homepage
 ├── getting-started.md          # Setup and basic usage
-├── deflation.md               # Deflation examples
+├── deflate.md                 # Deflation examples
 ├── exchange.md                # Currency exchange examples
 ├── data-sources.md            # IMF, World Bank, OECD comparison
 ├── migration.md               # v1 to v2 migration guide
@@ -124,8 +124,8 @@ result = imf_gdp_deflate(df, base_year=2015)
 ### Internal Links
 
 ```markdown
-[Link to another page](deflation.md)
-[Link to section](deflation.md#gdp-deflator)
+[Link to another page](deflate.md)
+[Link to section](deflate.md#gdp-deflator)
 ```
 
 ## Deployment

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -327,6 +327,6 @@ This data is provided based on the terms and conditions set by the original sour
 
 ## Next Steps
 
-- [**Deflation Guide**](deflation.md) - Apply deflators from each source
+- [**Deflation Guide**](deflate.md) - Apply deflators from each source
 - [**Currency Exchange**](exchange.md) - Use exchange rates from each source
 - [**Advanced Topics**](advanced/plugins.md) - Register custom data sources

--- a/docs/exchange.md
+++ b/docs/exchange.md
@@ -10,7 +10,7 @@ Use exchange functions when you need to:
 - Apply yearly average exchange rates
 - Work with historical exchange rates from authoritative sources
 
-For combined currency conversion + deflation, see the [Deflation Guide](deflation.md).
+For combined currency conversion + deflation, see the [Deflation Guide](deflate.md).
 
 ## IMF Exchange Rates
 
@@ -513,6 +513,6 @@ print(f"£{my_value_gbp_2021} in 2021 = ${value_usd:.2f}")
 
 ## Next Steps
 
-- [**Deflation Guide**](deflation.md) - Combine exchange with deflation
+- [**Deflation Guide**](deflate.md) - Combine exchange with deflation
 - [**Data Sources**](data-sources.md) - Detailed source comparison
 - [**Advanced Topics**](advanced/context.md) - Parallel processing and caching

--- a/docs/exchange.md
+++ b/docs/exchange.md
@@ -383,6 +383,134 @@ comparison['imf_dac_diff'] = comparison['usd_imf'] - comparison['usd_dac']
 print(comparison[['year', 'imf_wb_diff', 'imf_dac_diff']])
 ```
 
+## Getting Exchange Rates Directly
+
+**New in v2.3.0**: You can retrieve exchange rate data as DataFrames without providing your own data. This is useful for:
+
+- Inspecting exchange rates between currencies
+- Analyzing exchange rate trends
+- Pre-computing rates for manual calculations
+- Comparing rates across sources
+
+### Basic Usage
+
+```python
+from pydeflate import get_imf_exchange_rates, set_pydeflate_path
+
+set_pydeflate_path("./data")
+
+# Get exchange rates for specific currency pairs
+rates = get_imf_exchange_rates(
+    source_currency="USD",
+    target_currency="EUR",
+    countries=["USA", "FRA", "GBR"],  # Optional filter
+    years=range(2010, 2024),  # Optional filter
+)
+
+# Returns DataFrame with: iso_code, year, exchange_rate
+print(rates)
+```
+
+### Available Functions
+
+All exchange functions have corresponding "get" versions:
+
+- `get_imf_exchange_rates()` - IMF exchange rates
+- `get_wb_exchange_rates()` - World Bank exchange rates
+- `get_wb_ppp_rates()` - World Bank PPP conversion rates
+- `get_oecd_dac_exchange_rates()` - OECD DAC exchange rates
+
+### Example: Analyzing Exchange Rate Trends
+
+```python
+import matplotlib.pyplot as plt
+from pydeflate import get_imf_exchange_rates
+
+# Get EUR/USD rates over time
+rates = get_imf_exchange_rates(
+    source_currency="EUR",
+    target_currency="USD",
+    years=range(2000, 2024)
+)
+
+# Filter for a specific country (e.g., France for EUR)
+fra_rates = rates[rates["iso_code"] == "FRA"]
+
+# Plot the trend
+plt.figure(figsize=(10, 6))
+plt.plot(fra_rates["year"], fra_rates["exchange_rate"], marker='o')
+plt.title("EUR/USD Exchange Rate (IMF)")
+plt.xlabel("Year")
+plt.ylabel("Exchange Rate")
+plt.grid(True)
+plt.show()
+```
+
+### Example: Comparing Sources
+
+```python
+from pydeflate import (
+    get_imf_exchange_rates,
+    get_wb_exchange_rates,
+    get_oecd_dac_exchange_rates
+)
+
+# Get GBP to USD rates from different sources
+imf_rates = get_imf_exchange_rates(
+    source_currency="GBR",
+    target_currency="USA",
+    countries=["GBR"],
+    years=[2020, 2021, 2022]
+)
+
+wb_rates = get_wb_exchange_rates(
+    source_currency="GBR",
+    target_currency="USA",
+    countries=["GBR"],
+    years=[2020, 2021, 2022]
+)
+
+dac_rates = get_oecd_dac_exchange_rates(
+    source_currency="GBR",
+    target_currency="USA",
+    countries=["GBR"],
+    years=[2020, 2021, 2022]
+)
+
+# Compare
+import pandas as pd
+comparison = pd.DataFrame({
+    'year': imf_rates['year'],
+    'imf_rate': imf_rates['exchange_rate'],
+    'wb_rate': wb_rates['exchange_rate'],
+    'dac_rate': dac_rates['exchange_rate']
+})
+
+print(comparison)
+```
+
+### Example: Manual Currency Conversion
+
+```python
+from pydeflate import get_imf_exchange_rates
+
+# Get rates
+rates = get_imf_exchange_rates(
+    source_currency="GBP",
+    target_currency="USD"
+)
+
+# Manual conversion
+my_value_gbp_2021 = 100  # GBP in 2021
+rate_2021 = rates[
+    (rates["iso_code"] == "GBR") &
+    (rates["year"] == 2021)
+]["exchange_rate"].iloc[0]
+
+value_usd = my_value_gbp_2021 * rate_2021
+print(f"£{my_value_gbp_2021} in 2021 = ${value_usd:.2f}")
+```
+
 ## Next Steps
 
 - [**Deflation Guide**](deflation.md) - Combine exchange with deflation

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -477,5 +477,5 @@ comparison = df.merge(
 ## Next Steps
 
 - [**Getting Started**](getting-started.md) - Basic setup and usage
-- [**Deflation Guide**](deflation.md) - Comprehensive deflation examples
+- [**Deflation Guide**](deflate.md) - Comprehensive deflation examples
 - [**Advanced Topics**](advanced/exceptions.md) - Error handling, contexts, plugins

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,7 +259,7 @@ result = imf_gdp_deflate(
 
 Now that you understand the basics, explore specific use cases:
 
-- [**Deflation Guide**](deflation.md) - Detailed examples for all deflation methods
+- [**Deflation Guide**](deflate.md) - Detailed examples for all deflation methods
 - [**Currency Exchange**](exchange.md) - Currency conversion without deflation
 - [**Data Sources**](data-sources.md) - Choosing between IMF, World Bank, and OECD DAC
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -174,7 +174,7 @@ Most money series mix price changes with quantities. To measure real change, con
 ## Next Steps
 
 - [Getting Started](getting-started.md) - Detailed setup and DataFrame requirements
-- [Deflation Guide](deflation.md) - All deflation methods with examples
+- [Deflation Guide](deflate.md) - All deflation methods with examples
 - [Currency Exchange](exchange.md) - Currency conversion examples
 - [Data Sources](data-sources.md) - When to use IMF vs World Bank vs OECD DAC
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -425,11 +425,11 @@ with warnings.catch_warnings():
 If you encounter issues during migration:
 
 1. Check the [FAQ](faq.md) for common problems
-2. Review [examples in the documentation](deflation.md)
+2. Review [examples in the documentation](deflate.md)
 3. Open an issue on [GitHub](https://github.com/jm-rivera/pydeflate/issues)
 
 ## Next Steps
 
 - [**Getting Started**](getting-started.md) - Learn v2.x basics
-- [**Deflation Guide**](deflation.md) - Explore all deflation functions
+- [**Deflation Guide**](deflate.md) - Explore all deflation functions
 - [**Advanced Features**](advanced/exceptions.md) - Error handling, contexts, plugins

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,18 +27,11 @@ theme:
     text: Inter
     code: Fira Code
   features:
-    - announce.dismiss
-    - content.action.edit
-    - content.action.view
     - content.code.annotate
     - content.code.copy
     - content.tabs.link
-    - content.tooltips
-    - navigation.footer
     - navigation.indexes
     - navigation.instant
-    - navigation.instant.progress
-    - navigation.path
     - navigation.sections
     - navigation.tabs
     - navigation.tabs.sticky
@@ -90,7 +83,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - User Guide:
-      - Deflation: deflation.md
+      - Deflation: deflate.md
       - Currency Exchange: exchange.md
       - Data Sources: data-sources.md
   - Advanced:
@@ -100,6 +93,8 @@ nav:
       - Schema Validation: advanced/validation.md
   - Migration Guide: migration.md
   - FAQ: faq.md
+
+strict: true
 
 extra:
   version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydeflate"
-version = "2.2.0"
+version = "2.3.0"
 description = "Package to convert current prices figures to constant prices and vice versa"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pydeflate/__init__.py
+++ b/src/pydeflate/__init__.py
@@ -1,5 +1,5 @@
 __author__ = """Jorge Rivera"""
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 from pydeflate.deflate.deflators import (
     imf_cpi_deflate,
@@ -10,12 +10,27 @@ from pydeflate.deflate.deflators import (
     wb_gdp_deflate,
     wb_gdp_linked_deflate,
 )
+from pydeflate.deflate.get_deflators import (
+    get_imf_cpi_deflators,
+    get_imf_cpi_e_deflators,
+    get_imf_gdp_deflators,
+    get_oecd_dac_deflators,
+    get_wb_cpi_deflators,
+    get_wb_gdp_deflators,
+    get_wb_gdp_linked_deflators,
+)
 from pydeflate.deflate.legacy_deflate import deflate
 from pydeflate.exchange.exchangers import (
     imf_exchange,
     oecd_dac_exchange,
     wb_exchange,
     wb_exchange_ppp,
+)
+from pydeflate.exchange.get_rates import (
+    get_imf_exchange_rates,
+    get_oecd_dac_exchange_rates,
+    get_wb_exchange_rates,
+    get_wb_ppp_rates,
 )
 from pydeflate.pydeflate_config import set_data_dir, setup_logger
 
@@ -60,11 +75,24 @@ __all__ = [
     "wb_cpi_deflate",
     "wb_gdp_deflate",
     "wb_gdp_linked_deflate",
+    # Get deflators functions
+    "get_imf_cpi_deflators",
+    "get_imf_cpi_e_deflators",
+    "get_imf_gdp_deflators",
+    "get_oecd_dac_deflators",
+    "get_wb_cpi_deflators",
+    "get_wb_gdp_deflators",
+    "get_wb_gdp_linked_deflators",
     # Exchange functions
     "imf_exchange",
     "oecd_dac_exchange",
     "wb_exchange",
     "wb_exchange_ppp",
+    # Get exchange rates functions
+    "get_imf_exchange_rates",
+    "get_oecd_dac_exchange_rates",
+    "get_wb_exchange_rates",
+    "get_wb_ppp_rates",
     # Configuration
     "set_pydeflate_path",
     "setup_logger",

--- a/src/pydeflate/deflate/get_deflators.py
+++ b/src/pydeflate/deflate/get_deflators.py
@@ -1,0 +1,233 @@
+from functools import wraps
+
+import pandas as pd
+
+from pydeflate.core.api import BaseDeflate
+from pydeflate.core.source import DAC, IMF, WorldBank
+
+
+def _generate_get_deflator_docstring(source_name: str, price_kind: str) -> str:
+    """Generate docstring for each get deflator function."""
+    return (
+        f"Get deflator data from {source_name} ({price_kind}) without requiring user data.\n\n"
+        f"This function returns a DataFrame containing deflator values for the specified parameters.\n\n"
+        "Args:\n"
+        "    base_year (int): The base year for calculating deflation adjustments.\n"
+        "    source_currency (str, optional): The source currency code. Defaults to 'USA'.\n"
+        "    target_currency (str, optional): The target currency code. Defaults to 'USA'.\n"
+        "    countries (list[str] | None, optional): List of country codes to include. If None, returns all. Defaults to None.\n"
+        "    years (list[int] | range | None, optional): List or range of years to include. If None, returns all. Defaults to None.\n"
+        "    use_source_codes (bool, optional): Use source-specific entity codes. Defaults to False.\n"
+        "    to_current (bool, optional): Get deflators for constant-to-current conversion. Defaults to False.\n"
+        "    include_components (bool, optional): Include price_deflator, exchange_deflator, and exchange_rate columns. Defaults to False.\n"
+        "    update_deflators (bool, optional): Update the deflator data before retrieval. Defaults to False.\n\n"
+        "Returns:\n"
+        "    pd.DataFrame: DataFrame with columns:\n"
+        "        - iso_code (or entity_code if use_source_codes=True): Country/entity identifier\n"
+        "        - year: Year\n"
+        "        - deflator: The combined deflator value\n"
+        "        - price_deflator (if include_components=True): The price deflator component\n"
+        "        - exchange_deflator (if include_components=True): The exchange rate deflator component\n"
+        "        - exchange_rate (if include_components=True): The exchange rate\n"
+    )
+
+
+def _get_deflator(deflator_source_cls, price_kind):
+    """Decorator to create get_deflator wrappers with specific deflator source and price kind."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(
+            *,
+            base_year: int,
+            source_currency: str = "USA",
+            target_currency: str = "USA",
+            countries: list[str] | None = None,
+            years: list[int] | range | None = None,
+            use_source_codes: bool = False,
+            to_current: bool = False,
+            include_components: bool = False,
+            update_deflators: bool = False,
+        ):
+            # Validate input parameters
+            if not isinstance(base_year, int):
+                raise ValueError("The 'base_year' parameter must be an integer.")
+
+            # Initialize the deflator source
+            source = deflator_source_cls(update=update_deflators)
+
+            # Create a deflator object
+            deflator = BaseDeflate(
+                base_year=base_year,
+                deflator_source=source,
+                exchange_source=source,
+                source_currency=source_currency,
+                target_currency=target_currency,
+                price_kind=price_kind,
+                use_source_codes=use_source_codes,
+                to_current=to_current,
+            )
+
+            # Get the pydeflate data
+            data = deflator.pydeflate_data.copy()
+
+            # Determine the entity column based on use_source_codes
+            entity_col = "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+
+            # Filter by countries if specified
+            if countries is not None:
+                data = data[data[entity_col].isin(countries)]
+
+            # Filter by years if specified
+            if years is not None:
+                if isinstance(years, range):
+                    years = list(years)
+                data = data[data["pydeflate_year"].isin(years)]
+
+            # Select columns to return
+            columns_to_keep = [entity_col, "pydeflate_year", "pydeflate_deflator"]
+
+            if include_components:
+                # Add component columns
+                price_col = f"pydeflate_{price_kind}"
+                columns_to_keep.extend(
+                    [price_col, "pydeflate_EXCHANGE_D", "pydeflate_EXCHANGE"]
+                )
+
+            # Keep only the specified columns
+            result = data[columns_to_keep].copy()
+
+            # Rename columns to user-friendly names
+            rename_map = {
+                entity_col: "entity_code" if use_source_codes else "iso_code",
+                "pydeflate_year": "year",
+                "pydeflate_deflator": "deflator",
+            }
+
+            if include_components:
+                rename_map.update(
+                    {
+                        f"pydeflate_{price_kind}": "price_deflator",
+                        "pydeflate_EXCHANGE_D": "exchange_deflator",
+                        "pydeflate_EXCHANGE": "exchange_rate",
+                    }
+                )
+
+            result = result.rename(columns=rename_map)
+
+            # Reset index
+            result = result.reset_index(drop=True)
+
+            return result
+
+        wrapper.__doc__ = _generate_get_deflator_docstring(
+            deflator_source_cls.__name__, price_kind
+        )
+        return wrapper
+
+    return decorator
+
+
+@_get_deflator(DAC, "NGDP_D")
+def get_oecd_dac_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_deflator(WorldBank, "NGDP_D")
+def get_wb_gdp_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_deflator(WorldBank, "NGDP_DL")
+def get_wb_gdp_linked_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_deflator(WorldBank, "CPI")
+def get_wb_cpi_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_deflator(IMF, "NGDP_D")
+def get_imf_gdp_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_deflator(IMF, "PCPI")
+def get_imf_cpi_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_deflator(IMF, "PCPIE")
+def get_imf_cpi_e_deflators(
+    *,
+    base_year: int,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    to_current: bool = False,
+    include_components: bool = False,
+    update_deflators: bool = False,
+) -> pd.DataFrame: ...

--- a/src/pydeflate/exchange/get_rates.py
+++ b/src/pydeflate/exchange/get_rates.py
@@ -1,0 +1,207 @@
+from functools import wraps
+
+import pandas as pd
+
+from pydeflate.core.api import BaseExchange
+from pydeflate.core.source import DAC, IMF, WorldBank, WorldBankPPP
+
+
+def _generate_get_rates_docstring(source_name: str) -> str:
+    """Generate docstring for each get exchange rates function."""
+    return (
+        f"Get exchange rate data from {source_name} without requiring user data.\n\n"
+        f"This function returns a DataFrame containing exchange rates for the specified parameters.\n\n"
+        "Args:\n"
+        "    source_currency (str, optional): The source currency code. Defaults to 'USA'.\n"
+        "    target_currency (str, optional): The target currency code. Defaults to 'USA'.\n"
+        "    countries (list[str] | None, optional): List of country codes to include. If None, returns all. Defaults to None.\n"
+        "    years (list[int] | range | None, optional): List or range of years to include. If None, returns all. Defaults to None.\n"
+        "    use_source_codes (bool, optional): Use source-specific entity codes. Defaults to False.\n"
+        "    update_rates (bool, optional): Update the exchange rate data before retrieval. Defaults to False.\n\n"
+        "Returns:\n"
+        "    pd.DataFrame: DataFrame with columns:\n"
+        "        - iso_code (or entity_code if use_source_codes=True): Country/entity identifier\n"
+        "        - year: Year\n"
+        "        - exchange_rate: Exchange rate from source to target currency\n"
+    )
+
+
+def _get_exchange_rates(exchange_source_cls, **fixed_params):
+    """Decorator to create get_exchange_rates wrappers with specific source."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(
+            *,
+            source_currency: str = "USA",
+            target_currency: str = "USA",
+            countries: list[str] | None = None,
+            years: list[int] | range | None = None,
+            use_source_codes: bool = False,
+            update_rates: bool = False,
+        ):
+            # Apply fixed parameters - no validation needed since these are internally set
+            if "target_currency" in fixed_params:
+                target_currency = fixed_params["target_currency"]
+
+            # Initialize the exchange source
+            if exchange_source_cls.__name__ == "WorldBankPPP":
+                source = exchange_source_cls(
+                    update=update_rates,
+                    from_lcu=False if source_currency == "USA" else True,
+                )
+                source_currency = "LCU" if source_currency == "USA" else source_currency
+            else:
+                source = exchange_source_cls(update=update_rates)
+
+            # Create an exchange object
+            exchange = BaseExchange(
+                exchange_source=source,
+                source_currency=source_currency,
+                target_currency=target_currency,
+                use_source_codes=use_source_codes,
+            )
+
+            # Get the exchange rate data
+            data = exchange.pydeflate_data.copy()
+
+            # Determine the entity column based on use_source_codes
+            entity_col = "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+
+            # Filter by countries if specified
+            if countries is not None:
+                data = data[data[entity_col].isin(countries)]
+
+            # Filter by years if specified
+            if years is not None:
+                if isinstance(years, range):
+                    years = list(years)
+                data = data[data["pydeflate_year"].isin(years)]
+
+            # Select and rename columns
+            result = data[[entity_col, "pydeflate_year", "pydeflate_EXCHANGE"]].copy()
+            result = result.rename(
+                columns={
+                    entity_col: "entity_code" if use_source_codes else "iso_code",
+                    "pydeflate_year": "year",
+                    "pydeflate_EXCHANGE": "exchange_rate",
+                }
+            )
+
+            # Reset index
+            result = result.reset_index(drop=True)
+
+            return result
+
+        wrapper.__doc__ = _generate_get_rates_docstring(exchange_source_cls.__name__)
+        return wrapper
+
+    return decorator
+
+
+@_get_exchange_rates(DAC)
+def get_oecd_dac_exchange_rates(
+    *,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    update_rates: bool = False,
+) -> pd.DataFrame: ...
+
+
+@_get_exchange_rates(WorldBank)
+def get_wb_exchange_rates(
+    *,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    update_rates: bool = False,
+) -> pd.DataFrame: ...
+
+
+def get_wb_ppp_rates(
+    *,
+    source_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    update_rates: bool = False,
+) -> pd.DataFrame:
+    """Get PPP exchange rate data from WorldBankPPP without requiring user data.
+
+    This function returns a DataFrame containing PPP exchange rates for the specified parameters.
+
+    Args:
+        source_currency (str, optional): The source currency code. Defaults to 'USA'.
+        countries (list[str] | None, optional): List of country codes to include. If None, returns all. Defaults to None.
+        years (list[int] | range | None, optional): List or range of years to include. If None, returns all. Defaults to None.
+        use_source_codes (bool, optional): Use source-specific entity codes. Defaults to False.
+        update_rates (bool, optional): Update the exchange rate data before retrieval. Defaults to False.
+
+    Returns:
+        pd.DataFrame: DataFrame with columns:
+            - iso_code (or entity_code if use_source_codes=True): Country/entity identifier
+            - year: Year
+            - exchange_rate: PPP exchange rate
+    """
+    # Initialize the exchange source
+    source = WorldBankPPP(
+        update=update_rates,
+        from_lcu=False if source_currency == "USA" else True,
+    )
+    source_currency_internal = "LCU" if source_currency == "USA" else source_currency
+
+    # Create an exchange object with PPP as target
+    exchange = BaseExchange(
+        exchange_source=source,
+        source_currency=source_currency_internal,
+        target_currency="PPP",
+        use_source_codes=use_source_codes,
+    )
+
+    # Get the exchange rate data
+    data = exchange.pydeflate_data.copy()
+
+    # Determine the entity column based on use_source_codes
+    entity_col = "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+
+    # Filter by countries if specified
+    if countries is not None:
+        data = data[data[entity_col].isin(countries)]
+
+    # Filter by years if specified
+    if years is not None:
+        if isinstance(years, range):
+            years = list(years)
+        data = data[data["pydeflate_year"].isin(years)]
+
+    # Select and rename columns
+    result = data[[entity_col, "pydeflate_year", "pydeflate_EXCHANGE"]].copy()
+    result = result.rename(
+        columns={
+            entity_col: "entity_code" if use_source_codes else "iso_code",
+            "pydeflate_year": "year",
+            "pydeflate_EXCHANGE": "exchange_rate",
+        }
+    )
+
+    # Reset index
+    result = result.reset_index(drop=True)
+
+    return result
+
+
+@_get_exchange_rates(IMF)
+def get_imf_exchange_rates(
+    *,
+    source_currency: str = "USA",
+    target_currency: str = "USA",
+    countries: list[str] | None = None,
+    years: list[int] | range | None = None,
+    use_source_codes: bool = False,
+    update_rates: bool = False,
+) -> pd.DataFrame: ...

--- a/tests/integration/test_get_deflators.py
+++ b/tests/integration/test_get_deflators.py
@@ -1,0 +1,152 @@
+import pandas as pd
+import pytest
+
+from pydeflate import (
+    get_imf_cpi_deflators,
+    get_imf_cpi_e_deflators,
+    get_imf_gdp_deflators,
+    get_oecd_dac_deflators,
+    get_wb_cpi_deflators,
+    get_wb_gdp_deflators,
+    get_wb_gdp_linked_deflators,
+)
+from pydeflate import imf_gdp_deflate
+
+
+def test_get_imf_gdp_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting IMF GDP deflators."""
+    result = get_imf_gdp_deflators(
+        base_year=2022,
+        source_currency="USA",
+        target_currency="EUR",
+        countries=["USA", "FRA", "GBR"],
+        years=range(2021, 2024),
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    assert set(result.columns) == {"iso_code", "year", "deflator"}
+    assert all(result["year"] >= 2021) and all(result["year"] < 2024)
+    assert set(result["iso_code"].unique()).issubset({"USA", "FRA", "GBR"})
+
+
+def test_get_imf_cpi_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting IMF CPI deflators."""
+    result = get_imf_cpi_deflators(base_year=2022, countries=["USA", "GBR"])
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    assert "deflator" in result.columns
+
+
+def test_get_imf_cpi_e_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting IMF CPI-E deflators."""
+    result = get_imf_cpi_e_deflators(base_year=2022, countries=["USA"])
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_wb_gdp_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting World Bank GDP deflators."""
+    result = get_wb_gdp_deflators(base_year=2022, countries=["USA", "FRA"])
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_wb_gdp_linked_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting World Bank GDP linked deflators."""
+    result = get_wb_gdp_linked_deflators(base_year=2022)
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_wb_cpi_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting World Bank CPI deflators."""
+    result = get_wb_cpi_deflators(base_year=2022)
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_oecd_dac_deflators_full_workflow(sample_source_frames):
+    """Test complete workflow of getting OECD DAC deflators."""
+    result = get_oecd_dac_deflators(base_year=2022)
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_deflators_with_components(sample_source_frames):
+    """Test that include_components returns additional columns."""
+    result = get_imf_gdp_deflators(
+        base_year=2022, countries=["USA"], include_components=True
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert "price_deflator" in result.columns
+    assert "exchange_deflator" in result.columns
+    assert "exchange_rate" in result.columns
+    assert len(result.columns) == 6
+
+
+def test_get_deflators_consistency_with_deflate(sample_source_frames):
+    """Test that get_deflators returns consistent data with deflate functions."""
+    # Get deflators
+    deflators = get_imf_gdp_deflators(
+        base_year=2022,
+        source_currency="USA",
+        target_currency="USA",
+        countries=["USA"],
+        years=[2021],
+    )
+
+    # Create test data
+    test_data = pd.DataFrame(
+        {"iso_code": ["USA"], "year": [2021], "value": [100.0]}
+    )
+
+    # Deflate using the regular function
+    deflated = imf_gdp_deflate(data=test_data, base_year=2022, value_column="value")
+
+    # Get the deflator value
+    deflator_value = deflators[
+        (deflators["iso_code"] == "USA") & (deflators["year"] == 2021)
+    ]["deflator"].iloc[0]
+
+    # The deflated value should equal original / deflator
+    expected = 100.0 / deflator_value
+    actual = deflated["value"].iloc[0]
+
+    assert actual == pytest.approx(expected, rel=1e-6)
+
+
+def test_get_deflators_to_current_vs_constant(sample_source_frames):
+    """Test that to_current produces different deflators."""
+    constant = get_imf_gdp_deflators(
+        base_year=2022, countries=["USA"], years=[2021], to_current=False
+    )
+
+    current = get_imf_gdp_deflators(
+        base_year=2022, countries=["USA"], years=[2021], to_current=True
+    )
+
+    # Both should have data
+    assert len(constant) > 0
+    assert len(current) > 0
+
+    # Deflators should be different
+    constant_deflator = constant["deflator"].iloc[0]
+    current_deflator = current["deflator"].iloc[0]
+    assert constant_deflator != current_deflator
+
+
+def test_get_deflators_source_codes(sample_source_frames):
+    """Test that use_source_codes works correctly."""
+    result = get_imf_gdp_deflators(base_year=2022, use_source_codes=True)
+
+    assert "entity_code" in result.columns
+    assert "iso_code" not in result.columns
+    assert len(result) > 0

--- a/tests/integration/test_get_rates.py
+++ b/tests/integration/test_get_rates.py
@@ -1,0 +1,136 @@
+import pandas as pd
+import pytest
+
+from pydeflate import (
+    get_imf_exchange_rates,
+    get_oecd_dac_exchange_rates,
+    get_wb_exchange_rates,
+    get_wb_ppp_rates,
+)
+from pydeflate import imf_exchange
+
+
+def test_get_imf_exchange_rates_full_workflow(sample_source_frames):
+    """Test complete workflow of getting IMF exchange rates."""
+    result = get_imf_exchange_rates(
+        source_currency="USA",
+        target_currency="EUR",
+        countries=["USA", "FRA", "GBR"],
+        years=range(2021, 2024),
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    assert set(result.columns) == {"iso_code", "year", "exchange_rate"}
+    assert all(result["year"] >= 2021) and all(result["year"] < 2024)
+    assert set(result["iso_code"].unique()).issubset({"USA", "FRA", "GBR"})
+
+
+def test_get_wb_exchange_rates_full_workflow(sample_source_frames):
+    """Test complete workflow of getting World Bank exchange rates."""
+    result = get_wb_exchange_rates(countries=["USA", "FRA"])
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    assert "exchange_rate" in result.columns
+
+
+def test_get_oecd_dac_exchange_rates_full_workflow(sample_source_frames):
+    """Test complete workflow of getting OECD DAC exchange rates."""
+    result = get_oecd_dac_exchange_rates()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    assert "exchange_rate" in result.columns
+
+
+def test_get_wb_ppp_rates_full_workflow(sample_source_frames):
+    """Test complete workflow of getting World Bank PPP rates."""
+    result = get_wb_ppp_rates()
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    assert "exchange_rate" in result.columns
+
+
+def test_get_exchange_rates_consistency_with_exchange(sample_source_frames):
+    """Test that get_exchange_rates returns consistent data with exchange functions."""
+    # Get exchange rates
+    rates = get_imf_exchange_rates(
+        source_currency="USA",
+        target_currency="EUR",
+        countries=["FRA"],
+        years=[2021],
+    )
+
+    # Create test data
+    test_data = pd.DataFrame({"iso_code": ["FRA"], "year": [2021], "value": [100.0]})
+
+    # Exchange using the regular function
+    exchanged = imf_exchange(
+        data=test_data,
+        source_currency="USA",
+        target_currency="EUR",
+        value_column="value",
+    )
+
+    # Get the exchange rate value
+    rate_value = rates[
+        (rates["iso_code"] == "FRA") & (rates["year"] == 2021)
+    ]["exchange_rate"].iloc[0]
+
+    # The exchanged value should equal original * rate
+    expected = 100.0 * rate_value
+    actual = exchanged["value"].iloc[0]
+
+    assert actual == pytest.approx(expected, rel=1e-6)
+
+
+def test_get_exchange_rates_lcu_to_usd(sample_source_frames):
+    """Test LCU to USD exchange rates."""
+    result = get_imf_exchange_rates(
+        source_currency="LCU", target_currency="USA", countries=["FRA"]
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+    # Exchange rates should be positive
+    assert all(result["exchange_rate"] > 0)
+
+
+def test_get_exchange_rates_eur_to_gbp(sample_source_frames):
+    """Test EUR to GBP exchange rates."""
+    result = get_imf_exchange_rates(
+        source_currency="EUR", target_currency="GBP", years=[2021]
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_exchange_rates_source_codes(sample_source_frames):
+    """Test that use_source_codes works correctly."""
+    result = get_imf_exchange_rates(use_source_codes=True)
+
+    assert "entity_code" in result.columns
+    assert "iso_code" not in result.columns
+    assert len(result) > 0
+
+
+def test_get_wb_ppp_rates_no_target_currency():
+    """Test that PPP rates don't accept target_currency parameter."""
+    # The get_wb_ppp_rates function has target_currency fixed to 'PPP'
+    # This test just verifies the function works without that parameter
+    result = get_wb_ppp_rates(source_currency="USA")
+
+    assert isinstance(result, pd.DataFrame)
+
+
+def test_get_exchange_rates_common_currencies(sample_source_frames):
+    """Test that common currency codes work (USD, EUR, GBP, etc.)."""
+    result = get_imf_exchange_rates(
+        source_currency="USD", target_currency="EUR", countries=["USA"]
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0

--- a/tests/unit/test_get_deflators_unit.py
+++ b/tests/unit/test_get_deflators_unit.py
@@ -1,0 +1,124 @@
+import pandas as pd
+import pytest
+
+from pydeflate import get_imf_gdp_deflators, get_wb_cpi_deflators
+
+
+def test_get_deflators_returns_dataframe(sample_source_frames):
+    """Test that get_deflators returns a DataFrame with expected columns."""
+    result = get_imf_gdp_deflators(base_year=2022)
+
+    assert isinstance(result, pd.DataFrame)
+    assert "iso_code" in result.columns
+    assert "year" in result.columns
+    assert "deflator" in result.columns
+
+
+def test_get_deflators_with_country_filter(sample_source_frames):
+    """Test that get_deflators filters by countries correctly."""
+    result = get_imf_gdp_deflators(base_year=2022, countries=["USA", "FRA"])
+
+    assert set(result["iso_code"].unique()) == {"USA", "FRA"}
+
+
+def test_get_deflators_with_year_filter(sample_source_frames):
+    """Test that get_deflators filters by years correctly."""
+    result = get_imf_gdp_deflators(base_year=2022, years=[2021, 2022, 2023])
+
+    assert set(result["year"].unique()) == {2021, 2022, 2023}
+
+
+def test_get_deflators_with_year_range_filter(sample_source_frames):
+    """Test that get_deflators accepts a range for years."""
+    result = get_imf_gdp_deflators(base_year=2022, years=range(2021, 2024))
+
+    assert set(result["year"].unique()) == {2021, 2022, 2023}
+
+
+def test_get_deflators_with_combined_filters(sample_source_frames):
+    """Test that get_deflators applies multiple filters correctly."""
+    result = get_imf_gdp_deflators(
+        base_year=2022, countries=["USA", "GBR"], years=range(2021, 2023)
+    )
+
+    assert set(result["iso_code"].unique()).issubset({"USA", "GBR"})
+    assert set(result["year"].unique()).issubset({2021, 2022})
+
+
+def test_get_deflators_include_components(sample_source_frames):
+    """Test that include_components adds extra columns."""
+    result_without = get_imf_gdp_deflators(base_year=2022, include_components=False)
+    result_with = get_imf_gdp_deflators(base_year=2022, include_components=True)
+
+    assert len(result_without.columns) == 3
+    assert len(result_with.columns) == 6
+    assert "price_deflator" in result_with.columns
+    assert "exchange_deflator" in result_with.columns
+    assert "exchange_rate" in result_with.columns
+
+
+def test_get_deflators_use_source_codes(sample_source_frames):
+    """Test that use_source_codes changes the entity column name."""
+    result = get_imf_gdp_deflators(base_year=2022, use_source_codes=True)
+
+    assert "entity_code" in result.columns
+    assert "iso_code" not in result.columns
+
+
+def test_get_deflators_base_year_validation():
+    """Test that base_year must be an integer."""
+    with pytest.raises(ValueError, match="must be an integer"):
+        get_imf_gdp_deflators(base_year="2022")
+
+
+def test_get_deflators_different_currencies(sample_source_frames):
+    """Test that get_deflators works with different currency combinations."""
+    result = get_imf_gdp_deflators(
+        base_year=2022, source_currency="USA", target_currency="EUR"
+    )
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_deflators_to_current(sample_source_frames):
+    """Test that to_current parameter works."""
+    result_constant = get_imf_gdp_deflators(base_year=2022, to_current=False)
+    result_current = get_imf_gdp_deflators(base_year=2022, to_current=True)
+
+    # Both should return data, but with different deflator values
+    assert len(result_constant) > 0
+    assert len(result_current) > 0
+    # The deflators should be different
+    assert not result_constant["deflator"].equals(result_current["deflator"])
+
+
+def test_get_wb_cpi_deflators_works(sample_source_frames):
+    """Test that World Bank CPI deflators work."""
+    result = get_wb_cpi_deflators(base_year=2022)
+
+    assert isinstance(result, pd.DataFrame)
+    assert "deflator" in result.columns
+
+
+def test_get_deflators_no_filters_returns_all(sample_source_frames):
+    """Test that when no filters are applied, all data is returned."""
+    result = get_imf_gdp_deflators(base_year=2022)
+
+    # Should have multiple countries and years
+    assert len(result["iso_code"].unique()) > 1
+    assert len(result["year"].unique()) > 1
+
+
+def test_get_deflators_empty_filter_returns_empty(sample_source_frames):
+    """Test that empty filter lists return empty DataFrames."""
+    result = get_imf_gdp_deflators(base_year=2022, countries=[])
+
+    assert len(result) == 0
+
+
+def test_get_deflators_nonexistent_country_returns_empty(sample_source_frames):
+    """Test that filtering for non-existent countries returns empty DataFrame."""
+    result = get_imf_gdp_deflators(base_year=2022, countries=["XXX"])
+
+    assert len(result) == 0

--- a/tests/unit/test_get_rates_unit.py
+++ b/tests/unit/test_get_rates_unit.py
@@ -1,0 +1,120 @@
+import pandas as pd
+import pytest
+
+from pydeflate import (
+    get_imf_exchange_rates,
+    get_oecd_dac_exchange_rates,
+    get_wb_exchange_rates,
+    get_wb_ppp_rates,
+)
+
+
+def test_get_exchange_rates_returns_dataframe(sample_source_frames):
+    """Test that get_exchange_rates returns a DataFrame with expected columns."""
+    result = get_imf_exchange_rates()
+
+    assert isinstance(result, pd.DataFrame)
+    assert "iso_code" in result.columns
+    assert "year" in result.columns
+    assert "exchange_rate" in result.columns
+
+
+def test_get_exchange_rates_with_country_filter(sample_source_frames):
+    """Test that get_exchange_rates filters by countries correctly."""
+    result = get_imf_exchange_rates(countries=["USA", "FRA"])
+
+    assert set(result["iso_code"].unique()) == {"USA", "FRA"}
+
+
+def test_get_exchange_rates_with_year_filter(sample_source_frames):
+    """Test that get_exchange_rates filters by years correctly."""
+    result = get_imf_exchange_rates(years=[2021, 2022, 2023])
+
+    assert set(result["year"].unique()) == {2021, 2022, 2023}
+
+
+def test_get_exchange_rates_with_year_range_filter(sample_source_frames):
+    """Test that get_exchange_rates accepts a range for years."""
+    result = get_imf_exchange_rates(years=range(2021, 2024))
+
+    assert set(result["year"].unique()) == {2021, 2022, 2023}
+
+
+def test_get_exchange_rates_with_combined_filters(sample_source_frames):
+    """Test that get_exchange_rates applies multiple filters correctly."""
+    result = get_imf_exchange_rates(countries=["USA", "GBR"], years=range(2021, 2023))
+
+    assert set(result["iso_code"].unique()).issubset({"USA", "GBR"})
+    assert set(result["year"].unique()).issubset({2021, 2022})
+
+
+def test_get_exchange_rates_use_source_codes(sample_source_frames):
+    """Test that use_source_codes changes the entity column name."""
+    result = get_imf_exchange_rates(use_source_codes=True)
+
+    assert "entity_code" in result.columns
+    assert "iso_code" not in result.columns
+
+
+def test_get_exchange_rates_different_currencies(sample_source_frames):
+    """Test that get_exchange_rates works with different currency combinations."""
+    result = get_imf_exchange_rates(source_currency="USA", target_currency="EUR")
+
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+
+def test_get_wb_exchange_rates_works(sample_source_frames):
+    """Test that World Bank exchange rates work."""
+    result = get_wb_exchange_rates()
+
+    assert isinstance(result, pd.DataFrame)
+    assert "exchange_rate" in result.columns
+
+
+def test_get_oecd_dac_exchange_rates_works(sample_source_frames):
+    """Test that OECD DAC exchange rates work."""
+    result = get_oecd_dac_exchange_rates()
+
+    assert isinstance(result, pd.DataFrame)
+    assert "exchange_rate" in result.columns
+
+
+def test_get_wb_ppp_rates_works(sample_source_frames):
+    """Test that World Bank PPP rates work."""
+    result = get_wb_ppp_rates()
+
+    assert isinstance(result, pd.DataFrame)
+    assert "exchange_rate" in result.columns
+
+
+def test_get_exchange_rates_no_filters_returns_all(sample_source_frames):
+    """Test that when no filters are applied, all data is returned."""
+    result = get_imf_exchange_rates()
+
+    # Should have multiple countries and years
+    assert len(result["iso_code"].unique()) > 1
+    assert len(result["year"].unique()) > 1
+
+
+def test_get_exchange_rates_empty_filter_returns_empty(sample_source_frames):
+    """Test that empty filter lists return empty DataFrames."""
+    result = get_imf_exchange_rates(countries=[])
+
+    assert len(result) == 0
+
+
+def test_get_exchange_rates_nonexistent_country_returns_empty(sample_source_frames):
+    """Test that filtering for non-existent countries returns empty DataFrame."""
+    result = get_imf_exchange_rates(countries=["XXX"])
+
+    assert len(result) == 0
+
+
+def test_get_exchange_rates_same_source_target_currency(sample_source_frames):
+    """Test that same source and target currency returns rate of 1."""
+    result = get_imf_exchange_rates(source_currency="USA", target_currency="USA")
+
+    assert isinstance(result, pd.DataFrame)
+    # All exchange rates should be 1 when source equals target
+    assert all(result["exchange_rate"] == 1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ wheels = [
 
 [[package]]
 name = "pydeflate"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
This pull request introduces version 2.3.0 of the `pydeflate` package, adding major new functionality for retrieving deflator and exchange rate data directly as DataFrames, along with comprehensive updates to documentation and examples. The changes make it easier for users to access and analyze deflator and exchange rate data without providing their own datasets, and provide more flexibility for filtering and inspecting data.

**Key highlights:**
- New `get_*` functions allow users to directly retrieve deflators and exchange rates from all supported sources, with optional filtering by country and year.
- Users can now inspect the components of deflators (price deflator, exchange deflator, exchange rate) for deeper analysis.
- Documentation and guides have been extensively updated with practical examples and use cases for the new functions.
- Version bumped to 2.3.0.

### New Features

**Direct Data Retrieval Functions**
- Added new functions in `src/pydeflate/deflate/get_deflators.py` and `src/pydeflate/exchange/get_rates.py` to retrieve deflator and exchange rate data as DataFrames: `get_imf_gdp_deflators`, `get_imf_cpi_deflators`, `get_imf_cpi_e_deflators`, `get_wb_gdp_deflators`, `get_wb_gdp_linked_deflators`, `get_wb_cpi_deflators`, `get_oecd_dac_deflators`, `get_imf_exchange_rates`, `get_wb_exchange_rates`, `get_wb_ppp_rates`, `get_oecd_dac_exchange_rates`.
- All new functions support optional filtering by `countries` and `years`, and can include detailed deflator components via the `include_components` parameter.

**API and Versioning**
- Updated `src/pydeflate/__init__.py` to export the new `get_*` functions and reflect the new version [[1]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536L2-R2) [[2]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536R13-R34) [[3]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536R78-R95).
- Bumped version to 2.3.0 in `pyproject.toml` and `src/pydeflate/__init__.py` [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536L2-R2).

### Documentation Updates

**User Guides and Examples**
- Added a new "Getting Deflators and Exchange Rates Directly" section to `README.md`, with examples and use cases for the new functions [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R43) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R168-R272).
- Expanded the deflation and exchange guides (`docs/deflate.md`, `docs/exchange.md`) with detailed usage examples, including how to analyze trends, inspect components, and perform manual calculations [[1]](diffhunk://#diff-9f4db333b0e7d2e51dc40c1f56657c4cb4a1dc84072536aec56e7c6434d2fbfbL1-R5) [[2]](diffhunk://#diff-9f4db333b0e7d2e51dc40c1f56657c4cb4a1dc84072536aec56e7c6434d2fbfbR392-R497) [[3]](diffhunk://#diff-92d9887d6e17cddaf3b713effdd5b989177e4f72245b5e2422b5062b790b9f2eR386-R513).

**Changelog**
- Updated `CHANGELOG.md` to document the new features, changes, and use cases introduced in version 2.3.0.

---

**References**:  
[[1]](diffhunk://#diff-390599f9622333693d410e3363337f670b2947ff7e2a32bcfdc884de2ddfc106R1-R233) [[2]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536L2-R2) [[3]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536R13-R34) [[4]](diffhunk://#diff-254907f8845d2ea8b51437bfac683b9fc583270f55d70300353b56dc645ef536R78-R95) [[5]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R43) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R168-R272) [[8]](diffhunk://#diff-9f4db333b0e7d2e51dc40c1f56657c4cb4a1dc84072536aec56e7c6434d2fbfbL1-R5) [[9]](diffhunk://#diff-9f4db333b0e7d2e51dc40c1f56657c4cb4a1dc84072536aec56e7c6434d2fbfbR392-R497) [[10]](diffhunk://#diff-92d9887d6e17cddaf3b713effdd5b989177e4f72245b5e2422b5062b790b9f2eR386-R513) [[11]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R29)