### PR TITLE
Support newest imf-reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file. The format foll
 
 ## [Unreleased]
 
+## [2.3.1] - 2025-12-05
+### Changed
+- Increased minimum `imf-reader` version to 1.4.1 to support the new IMF SDMX API for fetching latest data.
+
 ## [2.3.0] - 2025-10-05
 ### Added
 - **Get Deflators Functions**: New functions to retrieve deflator data directly as DataFrames without requiring user data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydeflate"
-version = "2.3.0.post0"
+version = "2.3.1"
 description = "Package to convert current prices figures to constant prices and vice versa"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -11,7 +11,7 @@ license-files = ["LICENSE*"]
 
 dependencies = [
     "hdx-python-country>=3.9.8",
-    "imf-reader>=1.3.0",
+    "imf-reader>=1.4.1",
     "oda-reader>=1.3.0",
     "pandas>=2.0",
     "pandera>=0.20.0",

--- a/src/pydeflate/deflate/get_deflators.py
+++ b/src/pydeflate/deflate/get_deflators.py
@@ -72,7 +72,9 @@ def _get_deflator(deflator_source_cls, price_kind):
             data = deflator.pydeflate_data.copy()
 
             # Determine the entity column based on use_source_codes
-            entity_col = "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+            entity_col = (
+                "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+            )
 
             # Filter by countries if specified
             if countries is not None:

--- a/src/pydeflate/exchange/get_rates.py
+++ b/src/pydeflate/exchange/get_rates.py
@@ -66,7 +66,9 @@ def _get_exchange_rates(exchange_source_cls, **fixed_params):
             data = exchange.pydeflate_data.copy()
 
             # Determine the entity column based on use_source_codes
-            entity_col = "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+            entity_col = (
+                "pydeflate_entity_code" if use_source_codes else "pydeflate_iso3"
+            )
 
             # Filter by countries if specified
             if countries is not None:

--- a/tests/integration/test_get_deflators.py
+++ b/tests/integration/test_get_deflators.py
@@ -104,9 +104,7 @@ def test_get_deflators_consistency_with_deflate(sample_source_frames):
     )
 
     # Create test data
-    test_data = pd.DataFrame(
-        {"iso_code": ["USA"], "year": [2021], "value": [100.0]}
-    )
+    test_data = pd.DataFrame({"iso_code": ["USA"], "year": [2021], "value": [100.0]})
 
     # Deflate using the regular function
     deflated = imf_gdp_deflate(data=test_data, base_year=2022, value_column="value")

--- a/tests/integration/test_get_rates.py
+++ b/tests/integration/test_get_rates.py
@@ -75,9 +75,9 @@ def test_get_exchange_rates_consistency_with_exchange(sample_source_frames):
     )
 
     # Get the exchange rate value
-    rate_value = rates[
-        (rates["iso_code"] == "FRA") & (rates["year"] == 2021)
-    ]["exchange_rate"].iloc[0]
+    rate_value = rates[(rates["iso_code"] == "FRA") & (rates["year"] == 2021)][
+        "exchange_rate"
+    ].iloc[0]
 
     # The exchanged value should equal original * rate
     expected = 100.0 * rate_value

--- a/uv.lock
+++ b/uv.lock
@@ -284,6 +284,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8d7ae270bb5bc437b210bb9d6d9e46630c98f4abd20c/csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05", size = 237808, upload-time = "2017-11-26T21:13:08.238Z" }
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -515,17 +524,18 @@ wheels = [
 
 [[package]]
 name = "imf-reader"
-version = "1.3.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "chardet" },
+    { name = "diskcache" },
     { name = "pandas" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/45/24521d229aec5c058d998510794567788bc7b1b764dfaa02fb8e0aeda4b7/imf_reader-1.3.0.tar.gz", hash = "sha256:3f3130dd793a112fdd5913a7c7b733847a5a07fd70dee14d57624ae4e021a141", size = 12990, upload-time = "2025-02-06T09:16:10.723Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5a/c8bc268ae5b6dbab4db01d92f9d34713a7c487bc85f2522173cf24bc5c74/imf_reader-1.4.1.tar.gz", hash = "sha256:2584e45485b539cd2d15bf0a785e6ac5f29775c042d9d5f83c7af5d5f0947c0b", size = 13271, upload-time = "2025-12-05T11:41:01.049Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/5b/3a063116950f2aa2b450120e78162bb5b87098dde3b75ae90210c6f2c099/imf_reader-1.3.0-py3-none-any.whl", hash = "sha256:3515c6644dfef44d5fda89f5bb3786b4f83da20f49184911f0df2386782106f1", size = 16520, upload-time = "2025-02-06T09:16:09.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/79/97bd7b6c3af609b33ba2d787ea9e06ad93b1deca38388a345b6c913825ea/imf_reader-1.4.1-py3-none-any.whl", hash = "sha256:16c0dafcbe0e6630e7d3adbccb81e828b3e971b79e3969b79fbd6772151165c5", size = 19285, upload-time = "2025-12-05T11:41:00.218Z" },
 ]
 
 [[package]]
@@ -1357,7 +1367,7 @@ docs = [
 requires-dist = [
     { name = "filelock", specifier = ">=3.15.0" },
     { name = "hdx-python-country", specifier = ">=3.9.8" },
-    { name = "imf-reader", specifier = ">=1.3.0" },
+    { name = "imf-reader", specifier = ">=1.4.1" },
     { name = "oda-reader", specifier = ">=1.3.0" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pandera", specifier = ">=0.20.0" },
@@ -1797,6 +1807,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/150fdb96b8fab27fe08d8a59fe67554568727981806e6bc2677a16081ec7/ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539", size = 102394, upload-time = "2025-11-14T21:57:36.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e6/a3fa40084558c7e1dc9546385f22a93949c890a8b2e445b2ba43935f51da/ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008", size = 122673, upload-time = "2025-11-14T21:57:38.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the package to version 2.3.1, primarily increasing the minimum required version of the `imf-reader` dependency to support the new IMF SDMX API for fetching the latest data. 

This fixes #32

**Version and Dependency Updates**
* Bumped package version to `2.3.1` in `pyproject.toml` and documented the release in `CHANGELOG.md`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R10)
* Increased minimum `imf-reader` version to `1.4.1` in `pyproject.toml` to support the new IMF SDMX API. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L14-R14) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R10)