### PR TITLE
Fix EUR bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [2.3.2] - 2025-12-06
+### Fixed
+- Fixed "Euro area" entity name not mapping to EUR ISO3 code, which caused `ValueError: No currency exchange data for to_='EUR'` when using IMF data with EUR currency conversions.
+- Added additional entity name mappings for DAC data variants ("DAC Countries, Total", "Total DAC") to ensure consistent ISO3 code resolution.
 
 ## [2.3.1] - 2025-12-05
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydeflate"
-version = "2.3.1"
+version = "2.3.2"
 description = "Package to convert current prices figures to constant prices and vice versa"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pydeflate/sources/common.py
+++ b/src/pydeflate/sources/common.py
@@ -107,8 +107,11 @@ def add_pydeflate_iso3(
         additional_mapping={
             "World": "WLD",
             "European Union": "EUR",
+            "Euro area": "EUR",
             "EU Institutions": "EUI",
             "DAC countries": "DAC",
+            "DAC Countries, Total": "DAC",
+            "Total DAC": "DAC",
             "Kosovo": "XXK",
             "G7": "G7C",
             "Sub-Sahara Africa": "SSA",

--- a/tests/regression/test_euro_area_mapping.py
+++ b/tests/regression/test_euro_area_mapping.py
@@ -1,0 +1,102 @@
+"""Regression test for entity name mappings to ISO3 codes.
+
+Bug: IMF WEO data uses "Euro area" as the entity name for code 998,
+but the ISO3 mapping only had "European Union" -> "EUR", causing
+EUR currency lookups to fail with:
+    ValueError: No currency exchange data for to_='EUR'
+
+Fix: Added "Euro area": "EUR" and other variant mappings to add_pydeflate_iso3().
+"""
+
+import pandas as pd
+import pytest
+
+from pydeflate.sources.common import add_pydeflate_iso3
+
+
+class TestEuroAreaMapping:
+    """Tests for Euro area entity name mapping to EUR ISO3 code."""
+
+    def test_euro_area_maps_to_eur_iso3(self):
+        """Euro area entity name should map to EUR ISO3 code."""
+        df = pd.DataFrame(
+            {
+                "entity": ["Euro area"],
+                "entity_code": [998],
+                "year": [2022],
+            }
+        )
+
+        result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+        assert result["pydeflate_iso3"].iloc[0] == "EUR"
+
+    def test_european_union_also_maps_to_eur_iso3(self):
+        """European Union entity name should still map to EUR ISO3 code."""
+        df = pd.DataFrame(
+            {
+                "entity": ["European Union"],
+                "entity_code": [998],
+                "year": [2022],
+            }
+        )
+
+        result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+        assert result["pydeflate_iso3"].iloc[0] == "EUR"
+
+    def test_both_euro_names_map_consistently(self):
+        """Both 'Euro area' and 'European Union' should map to same ISO3."""
+        df = pd.DataFrame(
+            {
+                "entity": ["Euro area", "European Union"],
+                "entity_code": [998, 999],
+                "year": [2022, 2022],
+            }
+        )
+
+        result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+        assert result["pydeflate_iso3"].iloc[0] == "EUR"
+        assert result["pydeflate_iso3"].iloc[1] == "EUR"
+        assert result["pydeflate_iso3"].iloc[0] == result["pydeflate_iso3"].iloc[1]
+
+
+class TestDACEntityMapping:
+    """Tests for DAC entity name variants mapping to DAC ISO3 code."""
+
+    @pytest.mark.parametrize(
+        "entity_name",
+        [
+            "DAC countries",
+            "DAC Countries, Total",
+            "Total DAC",
+        ],
+    )
+    def test_dac_variants_map_to_dac_iso3(self, entity_name):
+        """All DAC entity name variants should map to DAC ISO3 code."""
+        df = pd.DataFrame(
+            {
+                "entity": [entity_name],
+                "entity_code": [20001],
+                "year": [2022],
+            }
+        )
+
+        result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+        assert result["pydeflate_iso3"].iloc[0] == "DAC"
+
+    def test_eu_institutions_maps_to_eui_iso3(self):
+        """EU Institutions should map to EUI ISO3 code (used by DAC)."""
+        df = pd.DataFrame(
+            {
+                "entity": ["EU Institutions"],
+                "entity_code": [918],
+                "year": [2022],
+            }
+        )
+
+        result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+        assert result["pydeflate_iso3"].iloc[0] == "EUI"


### PR DESCRIPTION
This pull request addresses a bug in entity name mappings to ISO3 codes, which caused currency conversion failures when using IMF and DAC data. It adds missing mappings for "Euro area" and a couple of DAC entity name variants, ensuring consistent ISO3 code resolution. The changes include updating the mapping logic, adding regression tests, and incrementing the package version.

Entity name mapping fixes:

* Added "Euro area" to map to the "EUR" ISO3 code and included additional DAC entity name variants ("DAC Countries, Total", "Total DAC") to map to "DAC" in the `add_pydeflate_iso3` function (`src/pydeflate/sources/common.py`).

Testing improvements:

* Added regression tests in `test_euro_area_mapping.py` to verify correct mapping of "Euro area", "European Union", and DAC entity name variants to their respective ISO3 codes.

Documentation and versioning:

* Updated `CHANGELOG.md` to document the bug fix and new entity name mappings.
* Bumped package version to 2.3.2 in `pyproject.toml`.

Closes #34