### PR TITLE
Fix CHN bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.4] - 2026-02-05
+### Fixed
+- Fixed IMF exchange rates for Hong Kong and Macao SARs being fuzzy-matched to CHN instead of HKG/MAC, which caused duplicate rows for China in exchange rate and deflator outputs (#38).
+
 ## [2.3.3] - 2025-12-07
 ### Fixed
 - Fixed EUR currency conversions with IMF data that were still failing after v2.3.2 due to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydeflate"
-version = "2.3.3"
+version = "2.3.4"
 description = "Package to convert current prices figures to constant prices and vice versa"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pydeflate/sources/common.py
+++ b/src/pydeflate/sources/common.py
@@ -118,6 +118,8 @@ def add_pydeflate_iso3(
             "Kosovo, Republic of": "XXK",
             "G7": "G7C",
             "Sub-Sahara Africa": "SSA",
+            "Hong Kong Special Administrative Region, People's Republic of China": "HKG",
+            "Macao Special Administrative Region, People's Republic of China": "MAC",
         },
     )
     return df

--- a/tests/regression/test_hkg_mac_mapping.py
+++ b/tests/regression/test_hkg_mac_mapping.py
@@ -1,0 +1,75 @@
+"""Regression test for issue #38.
+
+Hong Kong and Macao SAR entity names from IMF WEO data were fuzzy-matched to
+CHN instead of HKG / MAC, causing duplicate rows for China in exchange rate
+and deflator outputs.
+"""
+
+import pandas as pd
+
+from pydeflate.sources.common import add_pydeflate_iso3
+
+
+def test_hong_kong_maps_to_hkg_not_chn():
+    """Hong Kong SAR must be mapped to HKG, not fuzzy-matched to CHN."""
+    df = pd.DataFrame(
+        {
+            "entity": [
+                "China, People's Republic of",
+                "Hong Kong Special Administrative Region, People's Republic of China",
+            ],
+        }
+    )
+
+    # Use real fuzzy matching (the bug is in fuzzy matching results)
+    result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+    iso3_values = result["pydeflate_iso3"].tolist()
+    assert iso3_values[0] == "CHN", "Mainland China should map to CHN"
+    assert iso3_values[1] == "HKG", "Hong Kong SAR should map to HKG, not CHN"
+
+
+def test_macao_maps_to_mac_not_chn():
+    """Macao SAR must be mapped to MAC, not fuzzy-matched to CHN."""
+    df = pd.DataFrame(
+        {
+            "entity": [
+                "China, People's Republic of",
+                "Macao Special Administrative Region, People's Republic of China",
+            ],
+        }
+    )
+
+    result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+    iso3_values = result["pydeflate_iso3"].tolist()
+    assert iso3_values[0] == "CHN", "Mainland China should map to CHN"
+    assert iso3_values[1] == "MAC", "Macao SAR should map to MAC, not CHN"
+
+
+def test_no_duplicate_chn_rows_after_iso3_mapping():
+    """After ISO3 mapping, there should be exactly one row per (iso3, year)."""
+    df = pd.DataFrame(
+        {
+            "entity": [
+                "China, People's Republic of",
+                "Hong Kong Special Administrative Region, People's Republic of China",
+                "Macao Special Administrative Region, People's Republic of China",
+            ],
+            "year": [2022, 2022, 2022],
+            "value": [100.0, 200.0, 300.0],
+        }
+    )
+
+    result = add_pydeflate_iso3(df, column="entity", from_type="regex")
+
+    # Each entity should have a unique ISO3 code
+    chn_rows = result[result["pydeflate_iso3"] == "CHN"]
+    assert len(chn_rows) == 1, (
+        f"Expected 1 CHN row, got {len(chn_rows)} — "
+        "HKG/MAC are being fuzzy-matched to CHN"
+    )
+
+    # Verify HKG and MAC exist as separate entries
+    assert "HKG" in result["pydeflate_iso3"].values, "HKG should be present"
+    assert "MAC" in result["pydeflate_iso3"].values, "MAC should be present"


### PR DESCRIPTION
This pull request addresses a critical bug in the ISO3 entity mapping logic, specifically for Hong Kong and Macao SARs in IMF data. The main fix ensures these regions are correctly mapped to `HKG` and `MAC`, preventing them from being incorrectly fuzzy-matched to `CHN` and eliminating duplicate China rows in outputs. The update includes a version bump, changelog entry, and new regression tests to verify the fix.

**Bug fix: ISO3 mapping for Hong Kong and Macao SARs**

* Updated the mapping in `add_pydeflate_iso3` to explicitly map "Hong Kong Special Administrative Region, People's Republic of China" to `HKG` and "Macao Special Administrative Region, People's Republic of China" to `MAC`, preventing incorrect fuzzy matches to `CHN`.

**Testing improvements**

* Added a new regression test file `test_hkg_mac_mapping.py` to verify that Hong Kong and Macao SARs are mapped to the correct ISO3 codes and that duplicate `CHN` rows are not produced.

**Documentation and release management**

* Added a changelog entry describing the fix for the mapping bug affecting Hong Kong and Macao SARs.
* Bumped the package version to `2.3.4` in `pyproject.toml`.