### PR TITLE
Add configurable GDP-weighted deflator computation for country groups (EMU)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project are documented in this file. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.0] - 2026-03-07
+### Added
+- **Country Group Deflators**: Configurable GDP-weighted deflator computation for country groups like the Euro Area (EMU), addressing [#27](https://github.com/jm-rivera/pydeflate/issues/27).
+  - Three treatment modes via `set_group_treatment()`:
+    - `"source"` (default): Use the data source's own published aggregate (backward-compatible).
+    - `"fixed"`: GDP-weighted average of member countries' deflators using all-time membership.
+    - `"dynamic"`: GDP-weighted average using actual membership per year.
+  - Per-group configuration via `configure_group("EMU", treatment="fixed", members_year=2019)` to pin membership to a specific year for counterfactual analysis.
+  - Context manager integration: `pydeflate_session(group_treatment="fixed")` for scoped configuration.
+  - `emu_members(year)` function to query Euro Area membership for any year.
+- **Group Registry**: Extensible `GroupRegistry` with plugin-friendly `GroupDefinition` for registering custom country groups beyond EMU.
+- **EMU Membership Tracking**: Complete accession history for all 20 eurozone members (1999–2023), replacing the static `emu.json` file.
+
+### Changed
+- IMF source pipeline now preserves `NGDPD` (nominal GDP in USD) for GDP-weighted group deflator computation. Cache version bumped to `"3"`.
+- Removed `src/pydeflate/settings/emu.json` in favour of `src/pydeflate/groups/emu.py` with per-country accession years.
+- Removed the `emu()` helper from `utils.py`; the single caller in `world_bank.py` now imports directly from `groups.emu`.
+
 ## [2.3.5] - 2026-03-01
 ### Fixed
 - Added pandas 3.0 compatibility (#40):

--- a/docs/advanced/context.md
+++ b/docs/advanced/context.md
@@ -128,6 +128,19 @@ with pydeflate_session(enable_validation=True) as ctx:
 
 See [Schema Validation](validation.md) for details.
 
+### Group Treatment
+
+Control how country group deflators (e.g., Euro Area) are computed within a session:
+
+```python
+with pydeflate_session(group_treatment="fixed") as ctx:
+    # GDP-weighted EMU deflators inside this block
+    result = imf_gdp_deflate(df, base_year=2015, source_currency="EUR", ...)
+# Reverts to "source" (default) outside the block
+```
+
+See [Country Group Deflators](groups.md) for details on treatment modes.
+
 ### Combined Configuration
 
 ```python
@@ -136,7 +149,8 @@ import logging
 with pydeflate_session(
     data_dir="./cache",
     log_level=logging.INFO,
-    enable_validation=True
+    enable_validation=True,
+    group_treatment="fixed"
 ) as ctx:
     result = imf_gdp_deflate(df, context=ctx, ...)
 ```

--- a/docs/advanced/groups.md
+++ b/docs/advanced/groups.md
@@ -1,0 +1,180 @@
+# Country Group Deflators
+
+When deflating data denominated in a group currency like EUR, pydeflate needs a deflator for the group as a whole. By default it uses whatever aggregate the upstream data source (IMF, World Bank, OECD DAC) publishes. Starting in v2.4.0, you can instead compute GDP-weighted averages from member-country data, with full control over membership composition.
+
+## The Problem
+
+Source-published aggregates have limitations:
+
+- **Opaque methodology** — IMF, World Bank, and OECD each compute the Euro Area aggregate differently. You can't inspect or reproduce the calculation.
+- **Inconsistent membership** — Some sources lag behind membership changes. The IMF may not immediately reflect Croatia's 2023 accession in its Euro Area aggregate.
+- **No counterfactual analysis** — Researchers often need "what if we used 2015 membership for all years?" to isolate composition effects from price effects.
+
+## Treatment Modes
+
+pydeflate offers three modes for computing group deflators:
+
+### Source (default)
+
+Use the data source's own published aggregate. This is backward-compatible — pydeflate behaves exactly as before.
+
+```python
+import pydeflate
+
+# Default behavior, no configuration needed
+result = pydeflate.imf_gdp_deflate(
+    data=df,
+    base_year=2015,
+    source_currency="EUR",
+    target_currency="USD",
+)
+```
+
+### Fixed
+
+GDP-weighted average of member countries' deflators, using **all-time membership** for every year. This makes the series comparable across time but is historically inaccurate for pre-accession years (e.g., Croatia's deflator is included in all years even though it joined in 2023).
+
+```python
+pydeflate.set_group_treatment("fixed")
+
+result = pydeflate.imf_gdp_deflate(
+    data=df,
+    base_year=2015,
+    source_currency="EUR",
+    target_currency="USD",
+)
+```
+
+### Dynamic
+
+GDP-weighted average using the **actual membership in each year**. This is historically accurate (11 members in 1999, 20 in 2023) but creates composition-change artifacts at accession boundaries.
+
+```python
+pydeflate.set_group_treatment("dynamic")
+
+result = pydeflate.imf_gdp_deflate(
+    data=df,
+    base_year=2015,
+    source_currency="EUR",
+    target_currency="EUR",
+)
+```
+
+!!! tip "Choosing a mode"
+    - Use **source** when you want to match published data exactly.
+    - Use **fixed** when comparability across time matters more than historical accuracy.
+    - Use **dynamic** when you need historically accurate membership composition.
+
+## Per-Group Configuration
+
+Configure a specific group independently from the global default:
+
+```python
+# Pin EMU membership to 2019 (pre-COVID, pre-Croatia)
+pydeflate.configure_group("EMU", treatment="fixed", members_year=2019)
+
+result = pydeflate.imf_gdp_deflate(
+    data=df,
+    base_year=2015,
+    source_currency="EUR",
+    target_currency="EUR",
+)
+
+# Reset when done
+pydeflate.reset_group_config()
+```
+
+!!! note "EMU vs EUR"
+    `"EMU"` identifies the **country group** (European Monetary Union). `"EUR"` is the **currency code** used in `source_currency` and `target_currency`. This distinction avoids ambiguity: `configure_group("EMU", ...)` configures the group, while `source_currency="EUR"` specifies the currency.
+
+## Scoped Configuration
+
+Use `pydeflate_session` to set group treatment for a block of code, with automatic cleanup:
+
+```python
+from pydeflate import pydeflate_session
+
+with pydeflate_session(group_treatment="dynamic"):
+    # Dynamic membership inside this block
+    result = pydeflate.imf_gdp_deflate(
+        data=df,
+        base_year=2015,
+        source_currency="EUR",
+        target_currency="EUR",
+    )
+
+# Treatment automatically reverts to "source" here
+```
+
+This is useful in scripts that mix different treatment modes, or in applications where you want to avoid global state leaking between operations.
+
+## Querying Membership
+
+Inspect EMU membership at any point in time:
+
+```python
+>>> pydeflate.emu_members(1999)
+['AUT', 'BEL', 'DEU', 'ESP', 'FIN', 'FRA', 'IRL', 'ITA', 'LUX', 'NLD', 'PRT']
+
+>>> pydeflate.emu_members(2023)
+['AUT', 'BEL', 'CYP', 'DEU', 'ESP', 'EST', 'FIN', 'FRA', 'GRC', 'HRV',
+ 'IRL', 'ITA', 'LTU', 'LUX', 'LVA', 'MLT', 'NLD', 'PRT', 'SVK', 'SVN']
+
+>>> len(pydeflate.emu_members())  # all-time members
+20
+```
+
+## How It Works
+
+When a non-default treatment is active and you deflate with `source_currency="EUR"` (or `target_currency="EUR"`):
+
+1. pydeflate resolves the currency code `"EUR"` to the registered group `"EMU"`.
+2. It retrieves deflator values for each member country in the source data.
+3. It computes a GDP-weighted average (using nominal GDP in USD as weights) for each year, replacing the group's aggregate deflator row.
+4. If GDP data is unavailable for member countries, it falls back to equal-weight averaging.
+5. The rest of the deflation pipeline proceeds as usual — exchange rates are **not** modified (they are market rates, not aggregates).
+
+## Registering Custom Groups
+
+The group system is extensible. You can register any country group:
+
+```python
+from pydeflate.groups import GroupDefinition, _registry
+
+def asean_members(year: int) -> list[str]:
+    """Return ASEAN member ISO3 codes."""
+    members = ["BRN", "IDN", "KHM", "LAO", "MMR",
+               "MYS", "PHL", "SGP", "THA", "VNM"]
+    return sorted(members)
+
+_registry.register(
+    GroupDefinition(
+        key="ASEAN",
+        iso3="ASEAN",  # Must match the ISO3 code in your source data
+        name="ASEAN",
+        get_members=asean_members,
+    )
+)
+
+# Now you can configure it
+pydeflate.configure_group("ASEAN", treatment="fixed")
+```
+
+!!! warning
+    Custom groups only work if the source data contains an aggregate row with a matching `pydeflate_iso3` code. The built-in IMF, World Bank, and OECD sources include Euro Area aggregates (`EUR`) but may not include other groupings.
+
+## API Reference
+
+| Function | Description |
+|---|---|
+| `set_group_treatment(treatment)` | Set the default treatment for all groups (`"source"`, `"fixed"`, or `"dynamic"`) |
+| `configure_group(group, treatment=, members_year=)` | Configure a specific group by key (e.g., `"EMU"`) |
+| `reset_group_config()` | Reset all group configurations to defaults |
+| `emu_members(year=None)` | Return EMU member ISO3 codes (for a specific year, or all-time) |
+| `pydeflate_session(group_treatment=)` | Context manager with scoped group treatment |
+
+## Next Steps
+
+- [**Deflation Guide**](../deflate.md) — All deflation methods with examples
+- [**Context Management**](context.md) — Scoped configuration and parallel processing
+- [**Plugin System**](plugins.md) — Register custom data sources

--- a/docs/deflate.md
+++ b/docs/deflate.md
@@ -495,6 +495,43 @@ constant_value = my_value_2021 / deflator_2021
 print(f"${my_value_2021} in 2021 = ${constant_value:.2f} in constant 2020 USD")
 ```
 
+## Country Group Deflators (EUR / EMU)
+
+**New in v2.4.0**: When deflating EUR-denominated data, pydeflate can compute GDP-weighted deflators from individual eurozone member countries instead of relying on the source's opaque aggregate.
+
+```python
+import pydeflate
+
+# Use GDP-weighted average of all EMU members' deflators
+pydeflate.set_group_treatment("fixed")
+
+result = pydeflate.imf_gdp_deflate(
+    data=df,
+    base_year=2015,
+    source_currency="EUR",
+    target_currency="USD",
+)
+```
+
+You can also pin membership to a specific year:
+
+```python
+# Use 2019 membership for all years (pre-COVID, pre-Croatia)
+pydeflate.configure_group("EMU", treatment="fixed", members_year=2019)
+```
+
+Or use scoped configuration:
+
+```python
+from pydeflate import pydeflate_session
+
+with pydeflate_session(group_treatment="dynamic"):
+    # Uses actual membership per year (11 members in 1999, 20 in 2023)
+    result = pydeflate.imf_gdp_deflate(df, base_year=2015, ...)
+```
+
+For full details, see [Country Group Deflators](advanced/groups.md).
+
 ## Next Steps
 
 - [**Currency Exchange**](exchange.md) - Convert currencies without deflation

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,7 @@ wb_cpi_deflate(df, base_year=2020, source_currency="LCU", target_currency="USD",
 
 ### Advanced Features
 
+- **Country Group Deflators**: GDP-weighted deflators for groups like the Euro Area, with fixed or dynamic membership
 - **Plugin System**: Register custom data sources
 - **Context Management**: Multiple independent cache directories
 - **Schema Validation**: Optional data quality checks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Currency Exchange: exchange.md
       - Data Sources: data-sources.md
   - Advanced:
+      - Country Group Deflators: advanced/groups.md
       - Error Handling: advanced/exceptions.md
       - Context Management: advanced/context.md
       - Plugin System: advanced/plugins.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydeflate"
-version = "2.3.5"
+version = "2.4.0"
 description = "Package to convert current prices figures to constant prices and vice versa"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pydeflate/__init__.py
+++ b/src/pydeflate/__init__.py
@@ -111,7 +111,7 @@ def set_group_treatment(treatment: str) -> None:
 
 
 def configure_group(
-    iso3: str,
+    group: str,
     *,
     treatment: str,
     members_year: int | None = None,
@@ -119,16 +119,16 @@ def configure_group(
     """Configure how a specific group's deflators are computed.
 
     Args:
-        iso3: Group ISO3 code (e.g., "EUR")
+        group: Group key (e.g., "EMU"). See ``list_groups()`` for available groups.
         treatment: "source", "fixed", or "dynamic"
         members_year: Pin membership to a specific year (optional)
 
     Example:
-        >>> pydeflate.configure_group("EUR", treatment="fixed", members_year=2019)
+        >>> pydeflate.configure_group("EMU", treatment="fixed", members_year=2019)
     """
     from pydeflate.groups import _registry
 
-    _registry.configure(iso3, treatment=treatment, members_year=members_year)
+    _registry.configure(group, treatment=treatment, members_year=members_year)
 
 
 def reset_group_config() -> None:

--- a/src/pydeflate/__init__.py
+++ b/src/pydeflate/__init__.py
@@ -41,6 +41,11 @@ from pydeflate.context import (
     set_default_context,
     temporary_context,
 )
+from pydeflate.groups import GroupTreatment
+from pydeflate.groups.emu import (
+    all_members as _all_members,
+    members_for_year as _members_for_year,
+)
 from pydeflate.exceptions import (
     CacheError,
     ConfigurationError,
@@ -63,6 +68,74 @@ def set_pydeflate_path(path):
     """Set the path to the pydeflate data cache directory."""
 
     return set_data_dir(path)
+
+
+def emu_members(year: int | None = None) -> list[str]:
+    """Return ISO3 codes of EMU (eurozone) member countries.
+
+    Args:
+        year: If specified, return members as of that year.
+              If None, return all countries that have ever been members.
+
+    Returns:
+        Sorted list of ISO3 country codes.
+
+    Examples:
+        >>> emu_members(1999)
+        ['AUT', 'BEL', 'DEU', 'ESP', 'FIN', 'FRA', 'IRL', 'ITA', 'LUX', 'NLD', 'PRT']
+        >>> len(emu_members(2023))
+        20
+    """
+    if year is None:
+        return _all_members()
+    return _members_for_year(year)
+
+
+def set_group_treatment(treatment: str) -> None:
+    """Set how pydeflate treats ALL country groups in source data.
+
+    Args:
+        treatment: "source" (default), "fixed", or "dynamic"
+            - source: Use the data source's own published aggregate
+            - fixed: GDP-weighted average using current membership for all years
+            - dynamic: GDP-weighted average using actual membership per year
+
+    Example:
+        >>> import pydeflate
+        >>> pydeflate.set_group_treatment("fixed")
+        >>> result = pydeflate.imf_gdp_deflate(df, base_year=2015, source_currency="EUR", ...)
+    """
+    from pydeflate.groups import GroupTreatment as GT, _registry
+
+    _registry.default_treatment = GT(treatment)
+
+
+def configure_group(
+    iso3: str,
+    *,
+    treatment: str,
+    members_year: int | None = None,
+) -> None:
+    """Configure how a specific group's deflators are computed.
+
+    Args:
+        iso3: Group ISO3 code (e.g., "EUR")
+        treatment: "source", "fixed", or "dynamic"
+        members_year: Pin membership to a specific year (optional)
+
+    Example:
+        >>> pydeflate.configure_group("EUR", treatment="fixed", members_year=2019)
+    """
+    from pydeflate.groups import _registry
+
+    _registry.configure(iso3, treatment=treatment, members_year=members_year)
+
+
+def reset_group_config() -> None:
+    """Reset all group configurations to defaults."""
+    from pydeflate.groups import _registry
+
+    _registry.reset()
 
 
 __all__ = [
@@ -116,4 +189,10 @@ __all__ = [
     "is_source_registered",
     "list_sources",
     "register_source",
+    # Group treatment
+    "GroupTreatment",
+    "emu_members",
+    "set_group_treatment",
+    "configure_group",
+    "reset_group_config",
 ]

--- a/src/pydeflate/__init__.py
+++ b/src/pydeflate/__init__.py
@@ -1,5 +1,5 @@
 __author__ = """Jorge Rivera"""
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 from pydeflate.deflate.deflators import (
     imf_cpi_deflate,

--- a/src/pydeflate/context.py
+++ b/src/pydeflate/context.py
@@ -126,6 +126,7 @@ def pydeflate_session(
     data_dir: str | Path | None = None,
     log_level: int = logging.INFO,
     enable_validation: bool = True,
+    group_treatment: str | None = None,
     **config,
 ) -> Generator[PydeflateContext, None, None]:
     """Context manager for pydeflate operations with custom configuration.
@@ -143,6 +144,7 @@ def pydeflate_session(
         data_dir: Path to cache directory
         log_level: Logging level
         enable_validation: Enable schema validation
+        group_treatment: How to treat country groups ('source', 'fixed', 'dynamic')
         **config: Additional configuration
 
     Yields:
@@ -158,11 +160,20 @@ def pydeflate_session(
     # Save previous default context
     previous_context = getattr(_thread_local, "context", None)
 
+    # Save and restore group registry state
+    from pydeflate.groups import GroupTreatment as GT, _registry
+
+    previous_state = _registry.snapshot()
+
     try:
+        if group_treatment is not None:
+            _registry.default_treatment = GT(group_treatment)
         # Set as default for this thread
         set_default_context(context)
         yield context
     finally:
+        # Restore group registry state
+        _registry.restore(previous_state)
         # Restore previous context
         if previous_context is not None:
             set_default_context(previous_context)

--- a/src/pydeflate/core/api.py
+++ b/src/pydeflate/core/api.py
@@ -1,8 +1,12 @@
+import copy
+
 import pandas as pd
 
 from pydeflate.core.deflator import ExchangeDeflator, PriceDeflator
 from pydeflate.core.exchange import Exchange
+from pydeflate.core.group_deflator import compute_group_deflator
 from pydeflate.core.source import Source
+from pydeflate.groups import GroupTreatment, _registry
 from pydeflate.sources.common import AvailableDeflators
 from pydeflate.utils import (
     create_pydeflate_year,
@@ -26,6 +30,35 @@ def resolve_common_currencies(currency: str, source: str) -> str:
         mapping["EUR"] = "EUI"
 
     return mapping.get(currency, currency)
+
+
+def _maybe_apply_group_deflator(
+    source: Source, price_kind: str, currency_iso3: str
+) -> Source:
+    """Check if currency maps to a registered group and apply treatment if needed.
+
+    Uses copy.copy so the original source (which may also be used as
+    exchange_source) is not mutated.
+    """
+    if not _registry.is_group(currency_iso3):
+        return source
+
+    config = _registry.get_config(currency_iso3)
+    if config.treatment == GroupTreatment.SOURCE:
+        return source
+
+    group = _registry.get(currency_iso3)
+
+    modified = copy.copy(source)
+    modified.data = compute_group_deflator(
+        modified.data,
+        price_kind=price_kind,
+        group_iso3=group.iso3,
+        get_members=group.get_members,
+        dynamic=(config.treatment == GroupTreatment.DYNAMIC),
+        pin_year=config.members_year,
+    )
+    return modified
 
 
 def _base_operation(
@@ -262,6 +295,17 @@ class BaseDeflate:
         target_currency = resolve_common_currencies(
             target_currency, deflator_source.name
         )
+
+        # Apply group deflator treatment if configured.
+        # copy.copy ensures exchange_source (which may be the same object) is unaffected.
+        deflator_source = _maybe_apply_group_deflator(
+            deflator_source, price_kind, source_currency
+        )
+        if target_currency != source_currency:
+            deflator_source = _maybe_apply_group_deflator(
+                deflator_source, price_kind, target_currency
+            )
+
         self.exchange_rates = Exchange(
             source=exchange_source,
             source_currency=source_currency,

--- a/src/pydeflate/core/api.py
+++ b/src/pydeflate/core/api.py
@@ -40,14 +40,13 @@ def _maybe_apply_group_deflator(
     Uses copy.copy so the original source (which may also be used as
     exchange_source) is not mutated.
     """
-    if not _registry.is_group(currency_iso3):
+    group = _registry.find_by_iso3(currency_iso3)
+    if group is None:
         return source
 
-    config = _registry.get_config(currency_iso3)
+    config = _registry.get_config(group.key)
     if config.treatment == GroupTreatment.SOURCE:
         return source
-
-    group = _registry.get(currency_iso3)
 
     modified = copy.copy(source)
     modified.data = compute_group_deflator(

--- a/src/pydeflate/core/group_deflator.py
+++ b/src/pydeflate/core/group_deflator.py
@@ -1,0 +1,119 @@
+"""Compute GDP-weighted aggregate deflators for country groupings.
+
+This module is grouping-agnostic: it takes a membership resolver function
+and a group ISO3 code. Specific group data lives in pydeflate.groups.*.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pandas as pd
+
+from pydeflate.pydeflate_config import logger
+
+
+def compute_group_deflator(
+    data: pd.DataFrame,
+    price_kind: str,
+    group_iso3: str,
+    get_members: Callable[[int], list[str]],
+    dynamic: bool = False,
+    pin_year: int | None = None,
+) -> pd.DataFrame:
+    """Replace a group's aggregate deflator rows with GDP-weighted member average.
+
+    Args:
+        data: Source DataFrame with all countries including group aggregate rows.
+        price_kind: Deflator column suffix (e.g., "NGDP_D", "PCPI").
+        group_iso3: ISO3 code of the group aggregate row (e.g., "EUR").
+        get_members: Function returning member ISO3 codes for a given year.
+        dynamic: If True, use year-specific membership. If False, use all-time members.
+        pin_year: If set, use this year's membership for all rows (overrides dynamic).
+
+    Returns:
+        DataFrame with group aggregate deflator rows replaced.
+    """
+    deflator_col = f"pydeflate_{price_kind}"
+    if deflator_col not in data.columns:
+        return data
+
+    members = _select_member_rows(data, get_members, dynamic, pin_year)
+    if members.empty:
+        logger.warning(
+            "No member data found for group '%s'. Falling back to source aggregate.",
+            group_iso3,
+        )
+        return data
+
+    replacements = (
+        members.groupby("pydeflate_year", sort=False)
+        .apply(
+            _weighted_mean,
+            deflator_col=deflator_col,
+            group_iso3=group_iso3,
+            include_groups=False,
+        )
+        .dropna()
+        .round(6)
+    )
+
+    if replacements.empty:
+        return data
+
+    result = data.copy()
+    result[deflator_col] = result[deflator_col].astype("float64[pyarrow]")
+    mask = result["pydeflate_iso3"] == group_iso3
+    mapped = result.loc[mask, "pydeflate_year"].map(replacements)
+    has_value = mapped.notna()
+    result.loc[mapped.index[has_value], deflator_col] = mapped[has_value].values
+    return result
+
+
+def _select_member_rows(
+    data: pd.DataFrame,
+    get_members: Callable[[int], list[str]],
+    dynamic: bool,
+    pin_year: int | None,
+) -> pd.DataFrame:
+    """Filter data to rows belonging to group members."""
+    if pin_year is not None:
+        return data[data["pydeflate_iso3"].isin(get_members(pin_year))]
+
+    if not dynamic:
+        # All-time membership via far-future sentinel year
+        return data[data["pydeflate_iso3"].isin(get_members(9999))]
+
+    # Dynamic: membership varies by year
+    parts = [
+        data[
+            (data["pydeflate_year"] == year)
+            & data["pydeflate_iso3"].isin(get_members(int(year)))
+        ]
+        for year in data["pydeflate_year"].unique()
+    ]
+    return pd.concat(parts) if parts else data.iloc[0:0]
+
+
+def _weighted_mean(
+    group: pd.DataFrame, deflator_col: str, group_iso3: str
+) -> float:
+    """GDP-weighted mean of a deflator column, falling back to equal weights."""
+    deflators = group[deflator_col].dropna()
+    if deflators.empty:
+        return float("nan")
+
+    if "pydeflate_NGDPD" not in group.columns:
+        return float(deflators.mean())
+
+    gdp = group.loc[deflators.index, "pydeflate_NGDPD"].dropna()
+    if gdp.empty or gdp.sum() <= 0:
+        logger.warning(
+            "No GDP data for group '%s' members in %s, using equal weights",
+            group_iso3,
+            group.name,
+        )
+        return float(deflators.mean())
+
+    weights = gdp / gdp.sum()
+    return float((weights * group.loc[weights.index, deflator_col]).sum())

--- a/src/pydeflate/groups/__init__.py
+++ b/src/pydeflate/groups/__init__.py
@@ -1,0 +1,160 @@
+"""Country group registry and configuration.
+
+Manages how pydeflate treats aggregate rows for country groups
+(e.g., Euro Area, DAC members) in source data.
+
+Usage:
+    from pydeflate.groups import _registry
+
+    # Check if a currency code is a known group
+    _registry.is_group("EUR")  # True
+
+    # Get group definition
+    group = _registry.get("EUR")
+    group.get_members(2023)  # ['AUT', 'BEL', ..., 'HRV']
+
+    # Configure treatment
+    _registry.configure("EUR", treatment="fixed", members_year=2019)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+
+class GroupTreatment(str, Enum):
+    """How pydeflate computes deflators for country group rows.
+
+    SOURCE: Use the data source's own published aggregate (default).
+        Fast, backward-compatible. Methodology varies by source.
+
+    FIXED: GDP-weighted average using the latest/current membership for all years.
+        Comparable across time. Historically inaccurate for pre-accession years.
+
+    DYNAMIC: GDP-weighted average using the actual membership in each year.
+        Historically accurate. Creates composition-change artifacts at accession years.
+    """
+
+    SOURCE = "source"
+    FIXED = "fixed"
+    DYNAMIC = "dynamic"
+
+
+@dataclass(frozen=True)
+class GroupDefinition:
+    """A country group recognized in source data.
+
+    Attributes:
+        iso3: ISO3 code used for this group in pydeflate (e.g., "EUR").
+        name: Human-readable name (e.g., "Euro Area (EMU)").
+        get_members: Function returning member ISO3 codes for a given year.
+    """
+
+    iso3: str
+    name: str
+    get_members: Callable[[int], list[str]]
+
+
+@dataclass
+class GroupConfig:
+    """Runtime configuration for a specific group."""
+
+    treatment: GroupTreatment = GroupTreatment.SOURCE
+    members_year: int | None = None
+
+
+class GroupRegistry:
+    """Registry of known country groups and their treatment configs.
+
+    Note: This registry uses module-level state and is not thread-safe.
+    For thread-isolated configuration, use ``pydeflate_session``.
+    """
+
+    def __init__(self) -> None:
+        self._groups: dict[str, GroupDefinition] = {}
+        self._configs: dict[str, GroupConfig] = {}
+        self._default_treatment: GroupTreatment = GroupTreatment.SOURCE
+
+    def register(self, group: GroupDefinition) -> None:
+        """Register a country group."""
+        self._groups[group.iso3] = group
+
+    def is_group(self, iso3: str) -> bool:
+        """Check if an ISO3 code is a registered group."""
+        return iso3 in self._groups
+
+    def get(self, iso3: str) -> GroupDefinition | None:
+        """Get group definition by ISO3 code."""
+        return self._groups.get(iso3)
+
+    def configure(
+        self,
+        iso3: str,
+        *,
+        treatment: str | GroupTreatment,
+        members_year: int | None = None,
+    ) -> None:
+        """Set per-group configuration."""
+        if iso3 not in self._groups:
+            raise ValueError(
+                f"Unknown group '{iso3}'. Registered groups: {self.list_groups()}"
+            )
+        self._configs[iso3] = GroupConfig(
+            treatment=GroupTreatment(treatment),
+            members_year=members_year,
+        )
+
+    def get_config(self, iso3: str) -> GroupConfig:
+        """Get effective config (per-group override or global default)."""
+        if iso3 in self._configs:
+            return self._configs[iso3]
+        return GroupConfig(treatment=self._default_treatment)
+
+    @property
+    def default_treatment(self) -> GroupTreatment:
+        """Get the default treatment for all groups."""
+        return self._default_treatment
+
+    @default_treatment.setter
+    def default_treatment(self, value: GroupTreatment | str) -> None:
+        """Set the default treatment for all groups."""
+        self._default_treatment = GroupTreatment(value)
+
+    def list_groups(self) -> list[str]:
+        """List all registered group ISO3 codes."""
+        return sorted(self._groups.keys())
+
+    def snapshot(self) -> tuple[GroupTreatment, dict[str, GroupConfig]]:
+        """Capture current state for later restoration."""
+        return self._default_treatment, self._configs.copy()
+
+    def restore(self, state: tuple[GroupTreatment, dict[str, GroupConfig]]) -> None:
+        """Restore previously captured state."""
+        self._default_treatment, self._configs = state
+
+    def reset(self) -> None:
+        """Reset all configs to defaults (keeps registrations)."""
+        self._configs.clear()
+        self._default_treatment = GroupTreatment.SOURCE
+
+
+# Module-level singleton
+_registry = GroupRegistry()
+
+
+def _register_builtin_groups() -> None:
+    """Register pydeflate's built-in groups."""
+    from pydeflate.groups.emu import members_for_year
+
+    _registry.register(
+        GroupDefinition(
+            iso3="EUR",
+            name="Euro Area (EMU)",
+            get_members=members_for_year,
+        )
+    )
+
+
+_register_builtin_groups()

--- a/src/pydeflate/groups/__init__.py
+++ b/src/pydeflate/groups/__init__.py
@@ -6,15 +6,15 @@ Manages how pydeflate treats aggregate rows for country groups
 Usage:
     from pydeflate.groups import _registry
 
-    # Check if a currency code is a known group
-    _registry.is_group("EUR")  # True
+    # Check if a currency maps to a known group
+    _registry.find_by_iso3("EUR")  # GroupDefinition(key="EMU", ...)
 
-    # Get group definition
-    group = _registry.get("EUR")
+    # Get group definition by key
+    group = _registry.get("EMU")
     group.get_members(2023)  # ['AUT', 'BEL', ..., 'HRV']
 
     # Configure treatment
-    _registry.configure("EUR", treatment="fixed", members_year=2019)
+    _registry.configure("EMU", treatment="fixed", members_year=2019)
 """
 
 from __future__ import annotations
@@ -47,11 +47,13 @@ class GroupDefinition:
     """A country group recognized in source data.
 
     Attributes:
-        iso3: ISO3 code used for this group in pydeflate (e.g., "EUR").
+        key: User-facing identifier for this group (e.g., "EMU").
+        iso3: ISO3 code used for this group in source data (e.g., "EUR").
         name: Human-readable name (e.g., "Euro Area (EMU)").
         get_members: Function returning member ISO3 codes for a given year.
     """
 
+    key: str
     iso3: str
     name: str
     get_members: Callable[[int], list[str]]
@@ -68,48 +70,56 @@ class GroupConfig:
 class GroupRegistry:
     """Registry of known country groups and their treatment configs.
 
+    Groups are registered by ``key`` (e.g., "EMU") and looked up either by
+    key (public API) or by ``iso3`` (internal currency-to-group resolution).
+
     Note: This registry uses module-level state and is not thread-safe.
     For thread-isolated configuration, use ``pydeflate_session``.
     """
 
     def __init__(self) -> None:
         self._groups: dict[str, GroupDefinition] = {}
+        self._iso3_to_key: dict[str, str] = {}
         self._configs: dict[str, GroupConfig] = {}
         self._default_treatment: GroupTreatment = GroupTreatment.SOURCE
 
     def register(self, group: GroupDefinition) -> None:
         """Register a country group."""
-        self._groups[group.iso3] = group
+        self._groups[group.key] = group
+        self._iso3_to_key[group.iso3] = group.key
 
-    def is_group(self, iso3: str) -> bool:
-        """Check if an ISO3 code is a registered group."""
-        return iso3 in self._groups
+    def get(self, key: str) -> GroupDefinition | None:
+        """Get group definition by key (e.g., "EMU")."""
+        return self._groups.get(key)
 
-    def get(self, iso3: str) -> GroupDefinition | None:
-        """Get group definition by ISO3 code."""
-        return self._groups.get(iso3)
+    def find_by_iso3(self, iso3: str) -> GroupDefinition | None:
+        """Find group by its source-data ISO3 code (e.g., "EUR")."""
+        key = self._iso3_to_key.get(iso3)
+        if key is None:
+            return None
+        return self._groups.get(key)
 
     def configure(
         self,
-        iso3: str,
+        key: str,
         *,
         treatment: str | GroupTreatment,
         members_year: int | None = None,
     ) -> None:
         """Set per-group configuration."""
-        if iso3 not in self._groups:
+        if key not in self._groups:
             raise ValueError(
-                f"Unknown group '{iso3}'. Registered groups: {self.list_groups()}"
+                f"Unknown group '{key}'. Registered groups: {self.list_groups()}"
             )
-        self._configs[iso3] = GroupConfig(
+        self._configs[key] = GroupConfig(
             treatment=GroupTreatment(treatment),
             members_year=members_year,
         )
 
-    def get_config(self, iso3: str) -> GroupConfig:
+    def get_config(self, key: str) -> GroupConfig:
         """Get effective config (per-group override or global default)."""
-        if iso3 in self._configs:
-            return self._configs[iso3]
+        if key in self._configs:
+            return self._configs[key]
         return GroupConfig(treatment=self._default_treatment)
 
     @property
@@ -123,7 +133,7 @@ class GroupRegistry:
         self._default_treatment = GroupTreatment(value)
 
     def list_groups(self) -> list[str]:
-        """List all registered group ISO3 codes."""
+        """List all registered group keys."""
         return sorted(self._groups.keys())
 
     def snapshot(self) -> tuple[GroupTreatment, dict[str, GroupConfig]]:
@@ -150,6 +160,7 @@ def _register_builtin_groups() -> None:
 
     _registry.register(
         GroupDefinition(
+            key="EMU",
             iso3="EUR",
             name="Euro Area (EMU)",
             get_members=members_for_year,

--- a/src/pydeflate/groups/emu.py
+++ b/src/pydeflate/groups/emu.py
@@ -1,0 +1,53 @@
+"""EMU (European Monetary Union) membership tracking.
+
+Tracks which countries are in the eurozone for each year, enabling
+GDP-weighted deflator computation with historically accurate membership.
+"""
+
+from __future__ import annotations
+
+_EMU_ACCESSION: dict[str, int] = {
+    "AUT": 1999,
+    "BEL": 1999,
+    "DEU": 1999,
+    "ESP": 1999,
+    "FIN": 1999,
+    "FRA": 1999,
+    "IRL": 1999,
+    "ITA": 1999,
+    "LUX": 1999,
+    "NLD": 1999,
+    "PRT": 1999,
+    "GRC": 2001,
+    "SVN": 2007,
+    "CYP": 2008,
+    "MLT": 2008,
+    "SVK": 2009,
+    "EST": 2011,
+    "LVA": 2014,
+    "LTU": 2015,
+    "HRV": 2023,
+}
+
+
+def members_for_year(year: int) -> list[str]:
+    """Return sorted ISO3 codes of countries that were EMU members in the given year."""
+    return sorted(
+        iso3 for iso3, join_year in _EMU_ACCESSION.items() if join_year <= year
+    )
+
+
+def all_members() -> list[str]:
+    """Return all countries that have ever been EMU members."""
+    return sorted(_EMU_ACCESSION.keys())
+
+
+def accession_year(iso3: str) -> int | None:
+    """Return the year a country joined the eurozone, or None."""
+    return _EMU_ACCESSION.get(iso3)
+
+
+def is_member(iso3: str, year: int) -> bool:
+    """Check if a country was an EMU member in a given year."""
+    join_year = _EMU_ACCESSION.get(iso3)
+    return join_year is not None and join_year <= year

--- a/src/pydeflate/settings/emu.json
+++ b/src/pydeflate/settings/emu.json
@@ -1,1 +1,0 @@
-["AUT", "BEL", "CYP", "EST", "FIN", "FRA", "DEU", "GRC", "IRL", "ITA", "LVA", "LTU", "LUX", "MLT", "NLD", "PRT", "SVK", "SVN", "ESP"]

--- a/src/pydeflate/sources/imf.py
+++ b/src/pydeflate/sources/imf.py
@@ -132,8 +132,8 @@ def _compute_exchange(df: pd.DataFrame) -> pd.DataFrame:
     # Pivot the data so 'NGDPD' and 'NGDP' become separate columns
     exchange = exchange.pipe(_pivot_concept_code)
 
-    # Remove rows that correspond to 'NGDPD' and 'NGDP' from the original DataFrame
-    df = df.loc[lambda d: ~d.concept_code.isin(["NGDPD", "NGDP"])]
+    # Remove NGDP rows; keep NGDPD (GDP in USD) for GDP-weighted group deflators
+    df = df.loc[lambda d: ~d.concept_code.isin(["NGDP"])]
 
     # Compute the exchange rate as NGDP (local currency) divided by NGDPD (USD)
     exchange["value"] = round(exchange["NGDP"] / exchange["NGDPD"], 7)
@@ -204,7 +204,7 @@ _IMF_CACHE_ENTRY = CacheEntry(
     filename="imf_weo.parquet",
     fetcher=_download_weo,
     ttl_days=60,
-    version="2",  # Bump version to invalidate cache when EUR mapping fix is applied
+    version="3",  # Bump: preserve NGDPD for GDP-weighted group deflators
 )
 
 

--- a/src/pydeflate/sources/world_bank.py
+++ b/src/pydeflate/sources/world_bank.py
@@ -14,7 +14,7 @@ from pydeflate.sources.common import (
     enforce_pyarrow_types,
     prefix_pydeflate_to_columns,
 )
-from pydeflate.utils import emu
+from pydeflate.groups.emu import all_members as emu
 
 _INDICATORS: dict = {
     "NY.GDP.DEFL.ZS": "NGDP_D",  # GDP Deflator (Index)

--- a/src/pydeflate/utils.py
+++ b/src/pydeflate/utils.py
@@ -15,13 +15,6 @@ def oecd_codes() -> dict:
     return {int(k): v for k, v in updates.items()}
 
 
-def emu() -> list:
-    with open(PYDEFLATE_PATHS.settings / "emu.json") as file:
-        emu = json.load(file)
-
-    return emu
-
-
 def clean_number(number):
     """Clean a number-like value and return it as a float.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ YEARS = [2021, 2022, 2023]
 ENTITY_INFO = {
     "USA": {"iso": "USA", "code": "001"},
     "FRA": {"iso": "FRA", "code": "250"},
+    "DEU": {"iso": "DEU", "code": "134"},
     "GBR": {"iso": "GBR", "code": "826"},
     "CAN": {"iso": "CAN", "code": "124"},
     "EUR": {"iso": "EUR", "code": "978"},
@@ -84,12 +85,13 @@ def sample_source_frames():
     common_exchange_def = _uniform([96.0, 100.0, 104.0])
 
     imf_frames = _build_source_frame(
-        ["USA", "FRA", "GBR", "CAN", "EUR"],
+        ["USA", "FRA", "DEU", "GBR", "CAN", "EUR"],
         {
             "pydeflate_NGDP_D": _series(
                 {
                     "USA": [98.0, 100.0, 103.0],
                     "FRA": [95.0, 100.0, 108.0],
+                    "DEU": [96.0, 100.0, 106.0],
                     "GBR": [96.0, 100.0, 105.0],
                     "CAN": [97.0, 100.0, 104.0],
                     "EUR": [95.5, 100.0, 107.5],
@@ -99,6 +101,7 @@ def sample_source_frames():
                 {
                     "USA": [99.0, 100.0, 102.0],
                     "FRA": [96.0, 100.0, 107.0],
+                    "DEU": [97.0, 100.0, 105.0],
                     "GBR": [97.0, 100.0, 104.0],
                     "CAN": [98.0, 100.0, 103.0],
                     "EUR": [96.5, 100.0, 107.5],
@@ -108,6 +111,7 @@ def sample_source_frames():
                 {
                     "USA": [99.5, 100.0, 102.5],
                     "FRA": [96.5, 100.0, 107.5],
+                    "DEU": [97.5, 100.0, 106.5],
                     "GBR": [97.5, 100.0, 104.5],
                     "CAN": [98.5, 100.0, 103.5],
                     "EUR": [97.0, 100.0, 108.0],
@@ -117,12 +121,23 @@ def sample_source_frames():
                 {
                     "USA": [1.0, 1.0, 1.0],
                     "FRA": [0.84, 0.85, 0.86],
+                    "DEU": [0.84, 0.85, 0.86],
                     "GBR": [0.73, 0.74, 0.75],
                     "CAN": [1.26, 1.27, 1.28],
                     "EUR": [0.9, 0.91, 0.92],
                 }
             ),
             "pydeflate_EXCHANGE_D": common_exchange_def,
+            "pydeflate_NGDPD": _series(
+                {
+                    "USA": [23000.0, 25000.0, 27000.0],
+                    "FRA": [2800.0, 3000.0, 3200.0],
+                    "DEU": [4000.0, 4200.0, 4400.0],
+                    "GBR": [3000.0, 3200.0, 3400.0],
+                    "CAN": [1800.0, 2000.0, 2200.0],
+                    "EUR": [14000.0, 15000.0, 16000.0],
+                }
+            ),
         },
     )
 
@@ -282,6 +297,27 @@ def mock_source_readers(sample_source_frames, monkeypatch):
         lambda update=False: sample_source_frames["dac"],
     )
     yield
+
+
+@pytest.fixture
+def eur_df():
+    """DataFrame with EUR-denominated data for group deflator tests."""
+    return pd.DataFrame(
+        {
+            "iso_code": ["FRA", "FRA"],
+            "year": [2022, 2023],
+            "value": [1000.0, 1050.0],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_group_registry():
+    """Ensure group registry is reset after each test."""
+    yield
+    from pydeflate.groups import _registry
+
+    _registry.reset()
 
 
 @pytest.fixture

--- a/tests/integration/test_group_deflator_integration.py
+++ b/tests/integration/test_group_deflator_integration.py
@@ -1,0 +1,141 @@
+"""Integration tests for group deflator with registry-based configuration.
+
+Note: The conftest IMF data only has FRA and DEU as EMU members, so GDP-weighted
+averages here are computed from those two countries only. The unit tests in
+test_group_deflator.py cover the weighting logic more thoroughly.
+"""
+
+import pandas as pd
+import pytest
+
+from pydeflate import (
+    GroupTreatment,
+    configure_group,
+    emu_members,
+    imf_cpi_deflate,
+    imf_gdp_deflate,
+    imf_exchange,
+    pydeflate_session,
+    set_group_treatment,
+)
+from pydeflate.groups import _registry
+
+
+@pytest.fixture
+def eur_gbr_df():
+    return pd.DataFrame(
+        {
+            "iso_code": ["FRA", "FRA", "GBR", "GBR"],
+            "year": [2022, 2023, 2022, 2023],
+            "value": [1000.0, 1050.0, 2000.0, 2100.0],
+        }
+    )
+
+
+class TestIMFGDPDeflation:
+    def test_source_treatment(self, eur_gbr_df):
+        result = imf_gdp_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_fixed_treatment(self, eur_gbr_df):
+        set_group_treatment("fixed")
+        result = imf_gdp_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_dynamic_treatment(self, eur_gbr_df):
+        set_group_treatment("dynamic")
+        result = imf_gdp_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_no_treatment_works_as_before(self, eur_gbr_df):
+        result = imf_gdp_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_non_eur_currency_unaffected(self, eur_gbr_df):
+        set_group_treatment("fixed")
+        result = imf_gdp_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="USD",
+            target_currency="USD",
+        )
+        assert result["value"].notna().all()
+
+    def test_configure_group_with_pinning(self, eur_gbr_df):
+        configure_group("EUR", treatment="fixed", members_year=2019)
+        result = imf_gdp_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+
+class TestContextManager:
+    def test_session_with_group_treatment(self, eur_gbr_df):
+        with pydeflate_session(group_treatment="fixed"):
+            result = imf_gdp_deflate(
+                data=eur_gbr_df,
+                base_year=2022,
+                source_currency="EUR",
+                target_currency="EUR",
+            )
+            assert result["value"].notna().all()
+
+    def test_session_restores_state(self):
+        with pydeflate_session(group_treatment="dynamic"):
+            assert _registry.default_treatment == GroupTreatment.DYNAMIC
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+
+
+class TestCPIDeflation:
+    def test_cpi_with_fixed_treatment(self, eur_gbr_df):
+        set_group_treatment("fixed")
+        result = imf_cpi_deflate(
+            data=eur_gbr_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+
+class TestExchange:
+    def test_exchange_unaffected_by_treatment(self, eur_gbr_df):
+        """Exchange rates are market rates, not affected by group treatment."""
+        set_group_treatment("fixed")
+        result = imf_exchange(
+            data=eur_gbr_df,
+            source_currency="EUR",
+            target_currency="USD",
+        )
+        assert result["value"].notna().all()
+
+
+class TestEmuMembersPublic:
+    def test_founding_members(self):
+        assert len(emu_members(1999)) == 11
+
+    def test_all_members(self):
+        assert len(emu_members()) == 20

--- a/tests/integration/test_group_deflator_integration.py
+++ b/tests/integration/test_group_deflator_integration.py
@@ -82,7 +82,7 @@ class TestIMFGDPDeflation:
         assert result["value"].notna().all()
 
     def test_configure_group_with_pinning(self, eur_gbr_df):
-        configure_group("EUR", treatment="fixed", members_year=2019)
+        configure_group("EMU", treatment="fixed", members_year=2019)
         result = imf_gdp_deflate(
             data=eur_gbr_df,
             base_year=2022,

--- a/tests/property/test_group_deflator_properties.py
+++ b/tests/property/test_group_deflator_properties.py
@@ -1,0 +1,377 @@
+"""Property-based tests for group deflator operations.
+
+These tests use Hypothesis to verify mathematical properties that should
+always hold for GDP-weighted group deflators, regardless of specific input
+values. This catches edge cases in weighting, membership resolution, and
+numerical stability.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from pydeflate.core.group_deflator import compute_group_deflator
+from pydeflate.groups import GroupTreatment, _registry
+from pydeflate.groups.emu import all_members, is_member, members_for_year
+from pydeflate.sources.common import enforce_pyarrow_types
+
+settings.register_profile("default", max_examples=100, deadline=None)
+settings.load_profile("default")
+
+
+# ---------- Strategies ----------
+
+# Years where EMU membership is interesting (transitions happen)
+emu_year = st.integers(min_value=1995, max_value=2030)
+
+# Positive deflator values (realistic range)
+deflator_value = st.floats(min_value=50.0, max_value=200.0)
+
+# Positive GDP values in billions USD
+gdp_value = st.floats(min_value=1.0, max_value=50000.0)
+
+# Two-country weight split
+weight_split = st.floats(min_value=0.01, max_value=0.99)
+
+
+def _make_two_country_data(
+    defl_a: float,
+    defl_b: float,
+    gdp_a: float,
+    gdp_b: float,
+    year: int = 2022,
+) -> pd.DataFrame:
+    """Build a minimal source frame with 2 EMU members + EUR aggregate."""
+    records = [
+        {
+            "pydeflate_year": year,
+            "pydeflate_entity_code": "134",
+            "pydeflate_iso3": "DEU",
+            "pydeflate_NGDP_D": defl_a,
+            "pydeflate_EXCHANGE": 0.85,
+            "pydeflate_EXCHANGE_D": 100.0,
+            "pydeflate_NGDPD": gdp_a,
+        },
+        {
+            "pydeflate_year": year,
+            "pydeflate_entity_code": "250",
+            "pydeflate_iso3": "FRA",
+            "pydeflate_NGDP_D": defl_b,
+            "pydeflate_EXCHANGE": 0.85,
+            "pydeflate_EXCHANGE_D": 100.0,
+            "pydeflate_NGDPD": gdp_b,
+        },
+        {
+            "pydeflate_year": year,
+            "pydeflate_entity_code": "G163",
+            "pydeflate_iso3": "EUR",
+            "pydeflate_NGDP_D": 999.0,  # placeholder, will be replaced
+            "pydeflate_EXCHANGE": 0.85,
+            "pydeflate_EXCHANGE_D": 100.0,
+            "pydeflate_NGDPD": None,
+        },
+    ]
+    return enforce_pyarrow_types(pd.DataFrame.from_records(records))
+
+
+# ---------- EMU membership properties ----------
+
+
+class TestEMUMembershipProperties:
+    @given(year=emu_year)
+    def test_membership_is_monotonically_non_decreasing(self, year):
+        """Property: members(year) is a subset of members(year+1)."""
+        current = set(members_for_year(year))
+        next_year = set(members_for_year(year + 1))
+        assert current <= next_year
+
+    @given(year=emu_year)
+    def test_membership_count_bounded(self, year):
+        """Property: member count is between 0 and total ever-members."""
+        members = members_for_year(year)
+        assert 0 <= len(members) <= len(all_members())
+
+    @given(year=st.integers(min_value=2023, max_value=2100))
+    def test_membership_stable_after_latest_accession(self, year):
+        """Property: membership is stable after the latest accession (2023)."""
+        assert members_for_year(year) == members_for_year(2023)
+
+    @given(year=st.integers(min_value=1900, max_value=1998))
+    def test_no_members_before_1999(self, year):
+        """Property: no EMU members before 1999."""
+        assert members_for_year(year) == []
+
+    @given(year=emu_year)
+    def test_is_member_consistent_with_members_for_year(self, year):
+        """Property: is_member and members_for_year agree."""
+        members = members_for_year(year)
+        for iso3 in all_members():
+            assert is_member(iso3, year) == (iso3 in members)
+
+
+# ---------- GDP-weighted average properties ----------
+
+
+class TestWeightedAverageProperties:
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        gdp_a=gdp_value,
+        gdp_b=gdp_value,
+    )
+    def test_weighted_average_bounded_by_inputs(
+        self, defl_a, defl_b, gdp_a, gdp_b
+    ):
+        """Property: weighted average is between min and max of inputs."""
+        data = _make_two_country_data(defl_a, defl_b, gdp_a, gdp_b)
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        weighted = eur["pydeflate_NGDP_D"].iloc[0]
+
+        lo = min(defl_a, defl_b)
+        hi = max(defl_a, defl_b)
+        assert lo - 0.01 <= weighted <= hi + 0.01
+
+    @given(
+        defl=deflator_value,
+        gdp_a=gdp_value,
+        gdp_b=gdp_value,
+    )
+    def test_equal_deflators_produce_same_output(self, defl, gdp_a, gdp_b):
+        """Property: if all members have the same deflator, output equals it."""
+        data = _make_two_country_data(defl, defl, gdp_a, gdp_b)
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        assert abs(eur["pydeflate_NGDP_D"].iloc[0] - defl) < 0.01
+
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        gdp=gdp_value,
+    )
+    def test_equal_gdp_produces_simple_average(self, defl_a, defl_b, gdp):
+        """Property: equal GDP weights produce arithmetic mean."""
+        data = _make_two_country_data(defl_a, defl_b, gdp, gdp)
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        expected = (defl_a + defl_b) / 2.0
+        assert abs(eur["pydeflate_NGDP_D"].iloc[0] - expected) < 0.01
+
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        w=weight_split,
+    )
+    def test_weight_formula_correctness(self, defl_a, defl_b, w):
+        """Property: result matches the manual weighted-average formula."""
+        # Use weight_split to derive GDP values that produce known weights
+        total_gdp = 10000.0
+        gdp_a = total_gdp * w
+        gdp_b = total_gdp * (1 - w)
+
+        data = _make_two_country_data(defl_a, defl_b, gdp_a, gdp_b)
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+
+        expected = w * defl_a + (1 - w) * defl_b
+        assert abs(eur["pydeflate_NGDP_D"].iloc[0] - expected) < 0.01
+
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        gdp_a=gdp_value,
+        gdp_b=gdp_value,
+    )
+    def test_non_group_rows_invariant(self, defl_a, defl_b, gdp_a, gdp_b):
+        """Property: non-group rows are never modified."""
+        data = _make_two_country_data(defl_a, defl_b, gdp_a, gdp_b)
+
+        # Add a non-member row
+        extra = enforce_pyarrow_types(
+            pd.DataFrame(
+                [
+                    {
+                        "pydeflate_year": 2022,
+                        "pydeflate_entity_code": "001",
+                        "pydeflate_iso3": "USA",
+                        "pydeflate_NGDP_D": 105.0,
+                        "pydeflate_EXCHANGE": 1.0,
+                        "pydeflate_EXCHANGE_D": 100.0,
+                        "pydeflate_NGDPD": 25000.0,
+                    }
+                ]
+            )
+        )
+        data = pd.concat([data, extra], ignore_index=True)
+
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        usa = result[result["pydeflate_iso3"] == "USA"]
+        assert usa["pydeflate_NGDP_D"].iloc[0] == 105.0
+
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        gdp_a=gdp_value,
+        gdp_b=gdp_value,
+    )
+    def test_exchange_rate_never_modified(self, defl_a, defl_b, gdp_a, gdp_b):
+        """Property: exchange rates are never touched by group deflator."""
+        data = _make_two_country_data(defl_a, defl_b, gdp_a, gdp_b)
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        assert eur["pydeflate_EXCHANGE"].iloc[0] == 0.85
+        assert eur["pydeflate_EXCHANGE_D"].iloc[0] == 100.0
+
+
+# ---------- Treatment mode properties ----------
+
+
+class TestTreatmentModeProperties:
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        gdp_a=gdp_value,
+        gdp_b=gdp_value,
+    )
+    def test_fixed_and_dynamic_agree_after_all_accessions(
+        self, defl_a, defl_b, gdp_a, gdp_b
+    ):
+        """Property: for years after all accessions, fixed == dynamic."""
+        # Use year 2025, well after the last accession (2023)
+        data = _make_two_country_data(defl_a, defl_b, gdp_a, gdp_b, year=2025)
+
+        result_fixed = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        result_dynamic = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=True,
+        )
+
+        eur_fixed = result_fixed[result_fixed["pydeflate_iso3"] == "EUR"]
+        eur_dynamic = result_dynamic[result_dynamic["pydeflate_iso3"] == "EUR"]
+
+        assert abs(
+            eur_fixed["pydeflate_NGDP_D"].iloc[0]
+            - eur_dynamic["pydeflate_NGDP_D"].iloc[0]
+        ) < 0.01
+
+    @given(
+        defl_a=deflator_value,
+        defl_b=deflator_value,
+        gdp_a=gdp_value,
+        gdp_b=gdp_value,
+        pin_year=st.integers(min_value=2000, max_value=2030),
+    )
+    def test_pin_year_is_idempotent(
+        self, defl_a, defl_b, gdp_a, gdp_b, pin_year
+    ):
+        """Property: applying pin_year twice gives the same result."""
+        data = _make_two_country_data(defl_a, defl_b, gdp_a, gdp_b)
+
+        result1 = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=True,
+            pin_year=pin_year,
+        )
+        result2 = compute_group_deflator(
+            result1,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=True,
+            pin_year=pin_year,
+        )
+
+        eur1 = result1[result1["pydeflate_iso3"] == "EUR"]["pydeflate_NGDP_D"].iloc[0]
+        eur2 = result2[result2["pydeflate_iso3"] == "EUR"]["pydeflate_NGDP_D"].iloc[0]
+        assert abs(eur1 - eur2) < 0.01
+
+
+# ---------- Registry properties ----------
+
+
+class TestRegistryProperties:
+    @pytest.fixture(autouse=True)
+    def reset_registry(self):
+        yield
+        _registry.reset()
+
+    def test_snapshot_restore_is_identity(self):
+        """Property: snapshot then restore leaves registry unchanged."""
+        _registry.default_treatment = "fixed"
+        _registry.configure("EUR", treatment="dynamic", members_year=2019)
+
+        state = _registry.snapshot()
+        # Mutate
+        _registry.default_treatment = "source"
+        _registry.configure("EUR", treatment="source")
+        # Restore
+        _registry.restore(state)
+
+        assert _registry.default_treatment == GroupTreatment.FIXED
+        config = _registry.get_config("EUR")
+        assert config.treatment == GroupTreatment.DYNAMIC
+        assert config.members_year == 2019
+
+    @given(treatment=st.sampled_from(["source", "fixed", "dynamic"]))
+    def test_reset_always_returns_to_source(self, treatment):
+        """Property: reset always returns to SOURCE regardless of prior state."""
+        _registry.default_treatment = treatment
+        _registry.reset()
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+
+    @given(treatment=st.sampled_from(["source", "fixed", "dynamic"]))
+    def test_default_treatment_roundtrip(self, treatment):
+        """Property: setting then reading treatment returns same value."""
+        _registry.default_treatment = treatment
+        assert _registry.default_treatment == GroupTreatment(treatment)
+        _registry.reset()

--- a/tests/property/test_group_deflator_properties.py
+++ b/tests/property/test_group_deflator_properties.py
@@ -348,17 +348,17 @@ class TestRegistryProperties:
     def test_snapshot_restore_is_identity(self):
         """Property: snapshot then restore leaves registry unchanged."""
         _registry.default_treatment = "fixed"
-        _registry.configure("EUR", treatment="dynamic", members_year=2019)
+        _registry.configure("EMU", treatment="dynamic", members_year=2019)
 
         state = _registry.snapshot()
         # Mutate
         _registry.default_treatment = "source"
-        _registry.configure("EUR", treatment="source")
+        _registry.configure("EMU", treatment="source")
         # Restore
         _registry.restore(state)
 
         assert _registry.default_treatment == GroupTreatment.FIXED
-        config = _registry.get_config("EUR")
+        config = _registry.get_config("EMU")
         assert config.treatment == GroupTreatment.DYNAMIC
         assert config.members_year == 2019
 

--- a/tests/unit/test_emu.py
+++ b/tests/unit/test_emu.py
@@ -1,0 +1,46 @@
+from pydeflate.groups.emu import (
+    members_for_year,
+    all_members,
+    accession_year,
+    is_member,
+)
+
+
+class TestEMUMembership:
+    def test_founding_members_1999(self):
+        members = members_for_year(1999)
+        assert "DEU" in members
+        assert "FRA" in members
+        assert "ITA" in members
+        assert "ESP" in members
+        assert len(members) == 11
+
+    def test_greece_joins_2001(self):
+        assert "GRC" not in members_for_year(2000)
+        assert "GRC" in members_for_year(2001)
+
+    def test_croatia_joins_2023(self):
+        assert "HRV" not in members_for_year(2022)
+        assert "HRV" in members_for_year(2023)
+
+    def test_all_members_returns_20(self):
+        assert len(all_members()) == 20
+        assert "HRV" in all_members()
+
+    def test_accession_year(self):
+        assert accession_year("DEU") == 1999
+        assert accession_year("GRC") == 2001
+        assert accession_year("HRV") == 2023
+        assert accession_year("USA") is None
+
+    def test_is_member(self):
+        assert is_member("DEU", 2020) is True
+        assert is_member("HRV", 2022) is False
+        assert is_member("HRV", 2023) is True
+        assert is_member("USA", 2020) is False
+
+    def test_pre_euro_returns_empty(self):
+        assert members_for_year(1998) == []
+
+    def test_2023_includes_all_20(self):
+        assert len(members_for_year(2023)) == 20

--- a/tests/unit/test_group_context.py
+++ b/tests/unit/test_group_context.py
@@ -24,9 +24,9 @@ class TestGroupTreatmentContext:
 
     def test_session_restores_per_group_configs(self):
         with pydeflate_session(group_treatment="fixed"):
-            _registry.configure("EUR", treatment="dynamic", members_year=2019)
-            config = _registry.get_config("EUR")
+            _registry.configure("EMU", treatment="dynamic", members_year=2019)
+            config = _registry.get_config("EMU")
             assert config.members_year == 2019
         # After context, per-group config should be restored
-        config = _registry.get_config("EUR")
+        config = _registry.get_config("EMU")
         assert config.members_year is None

--- a/tests/unit/test_group_context.py
+++ b/tests/unit/test_group_context.py
@@ -1,0 +1,32 @@
+"""Test group treatment integration with pydeflate_session."""
+
+from pydeflate import imf_gdp_deflate, pydeflate_session
+from pydeflate.groups import _registry, GroupTreatment
+
+
+class TestGroupTreatmentContext:
+    def test_session_sets_treatment(self, eur_df):
+        with pydeflate_session(group_treatment="fixed"):
+            assert _registry.default_treatment == GroupTreatment.FIXED
+            result = imf_gdp_deflate(
+                data=eur_df,
+                base_year=2022,
+                source_currency="EUR",
+                target_currency="EUR",
+            )
+            assert result["value"].notna().all()
+
+    def test_session_restores_treatment(self):
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+        with pydeflate_session(group_treatment="dynamic"):
+            assert _registry.default_treatment == GroupTreatment.DYNAMIC
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+
+    def test_session_restores_per_group_configs(self):
+        with pydeflate_session(group_treatment="fixed"):
+            _registry.configure("EUR", treatment="dynamic", members_year=2019)
+            config = _registry.get_config("EUR")
+            assert config.members_year == 2019
+        # After context, per-group config should be restored
+        config = _registry.get_config("EUR")
+        assert config.members_year is None

--- a/tests/unit/test_group_deflator.py
+++ b/tests/unit/test_group_deflator.py
@@ -1,0 +1,146 @@
+"""Tests for GDP-weighted group deflator computation."""
+
+import pandas as pd
+import pytest
+
+from pydeflate.core.group_deflator import compute_group_deflator
+from pydeflate.groups.emu import members_for_year
+from pydeflate.sources.common import enforce_pyarrow_types
+
+
+def _make_source_data() -> pd.DataFrame:
+    """Create minimal source data with 2 EMU members (DEU, FRA) and USA."""
+    records = []
+    for iso3, code, gdp_values, deflator_values, exchange_values in [
+        (
+            "DEU",
+            "134",
+            [4000.0, 4200.0, 4400.0],
+            [95.0, 100.0, 106.0],
+            [0.84, 0.85, 0.86],
+        ),
+        (
+            "FRA",
+            "250",
+            [2800.0, 3000.0, 3200.0],
+            [96.0, 100.0, 108.0],
+            [0.84, 0.85, 0.86],
+        ),
+        (
+            "USA",
+            "001",
+            [23000.0, 25000.0, 27000.0],
+            [98.0, 100.0, 103.0],
+            [1.0, 1.0, 1.0],
+        ),
+        (
+            "EUR",
+            "G163",
+            [None, None, None],
+            [95.5, 100.0, 107.0],
+            [0.84, 0.85, 0.86],
+        ),
+    ]:
+        for i, year in enumerate([2021, 2022, 2023]):
+            records.append(
+                {
+                    "pydeflate_year": year,
+                    "pydeflate_entity_code": code,
+                    "pydeflate_iso3": iso3,
+                    "pydeflate_NGDP_D": deflator_values[i],
+                    "pydeflate_EXCHANGE": exchange_values[i],
+                    "pydeflate_EXCHANGE_D": [96.0, 100.0, 104.0][i],
+                    "pydeflate_NGDPD": gdp_values[i],
+                }
+            )
+    return enforce_pyarrow_types(pd.DataFrame.from_records(records))
+
+
+class TestComputeGroupDeflator:
+    def test_fixed_computes_weighted_average(self):
+        data = _make_source_data()
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+
+        # 2022: DEU=4200, FRA=3000, both deflator=100 -> weighted=100
+        assert eur[eur["pydeflate_year"] == 2022]["pydeflate_NGDP_D"].iloc[
+            0
+        ] == pytest.approx(100.0, abs=0.1)
+
+        # 2023: DEU weight=4400/7600=0.5789, FRA weight=3200/7600=0.4211
+        # Weighted = 0.5789*106 + 0.4211*108 = 106.84
+        val_2023 = eur[eur["pydeflate_year"] == 2023]["pydeflate_NGDP_D"].iloc[0]
+        assert val_2023 != 107.0
+        assert val_2023 == pytest.approx(106.84, abs=0.1)
+
+    def test_non_group_rows_unchanged(self):
+        data = _make_source_data()
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        usa = result[result["pydeflate_iso3"] == "USA"]
+        assert usa["pydeflate_NGDP_D"].tolist() == [98.0, 100.0, 103.0]
+
+    def test_exchange_rate_not_modified(self):
+        data = _make_source_data()
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        assert eur["pydeflate_EXCHANGE"].tolist() == [0.84, 0.85, 0.86]
+
+    def test_missing_ngdpd_falls_back_to_equal_weight(self):
+        data = _make_source_data()
+        data.loc[data["pydeflate_iso3"].isin(["DEU", "FRA"]), "pydeflate_NGDPD"] = None
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        # Equal weight: (106 + 108) / 2 = 107.0
+        val_2023 = eur[eur["pydeflate_year"] == 2023]["pydeflate_NGDP_D"].iloc[0]
+        assert val_2023 == pytest.approx(107.0, abs=0.1)
+
+    def test_pin_year_uses_fixed_membership(self):
+        data = _make_source_data()
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=True,
+            pin_year=2020,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        assert eur["pydeflate_NGDP_D"].notna().all()
+
+    def test_no_members_in_data_preserves_source(self):
+        data = _make_source_data()
+        data = data[~data["pydeflate_iso3"].isin(["DEU", "FRA"])]
+        result = compute_group_deflator(
+            data,
+            price_kind="NGDP_D",
+            group_iso3="EUR",
+            get_members=members_for_year,
+            dynamic=False,
+        )
+        eur = result[result["pydeflate_iso3"] == "EUR"]
+        # Unchanged - source aggregate preserved when no member data found
+        assert eur[eur["pydeflate_year"] == 2023]["pydeflate_NGDP_D"].iloc[0] == 107.0

--- a/tests/unit/test_group_integration.py
+++ b/tests/unit/test_group_integration.py
@@ -30,7 +30,7 @@ class TestGroupRegistryIntegration:
 
     def test_configure_group_with_members_year(self, eur_df):
         """Per-group config with membership pinning."""
-        _registry.configure("EUR", treatment="fixed", members_year=2019)
+        _registry.configure("EMU", treatment="fixed", members_year=2019)
         result = imf_gdp_deflate(
             data=eur_df,
             base_year=2022,

--- a/tests/unit/test_group_integration.py
+++ b/tests/unit/test_group_integration.py
@@ -1,0 +1,68 @@
+"""Test that group registry integrates with BaseDeflate."""
+
+import pandas as pd
+
+from pydeflate import imf_gdp_deflate
+from pydeflate.groups import _registry
+
+
+class TestGroupRegistryIntegration:
+    def test_default_treatment_unchanged(self, eur_df):
+        """With SOURCE treatment, behavior is unchanged."""
+        result = imf_gdp_deflate(
+            data=eur_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_fixed_treatment(self, eur_df):
+        """FIXED treatment applies GDP-weighted deflator."""
+        _registry.default_treatment = "fixed"
+        result = imf_gdp_deflate(
+            data=eur_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_configure_group_with_members_year(self, eur_df):
+        """Per-group config with membership pinning."""
+        _registry.configure("EUR", treatment="fixed", members_year=2019)
+        result = imf_gdp_deflate(
+            data=eur_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        assert result["value"].notna().all()
+
+    def test_non_eur_unaffected_by_treatment(self, eur_df):
+        """Non-group currencies are not affected by group treatment."""
+        _registry.default_treatment = "fixed"
+        result = imf_gdp_deflate(
+            data=eur_df,
+            base_year=2022,
+            source_currency="USD",
+            target_currency="USD",
+        )
+        assert result["value"].notna().all()
+
+    def test_source_treatment_matches_no_treatment(self, eur_df):
+        """Explicit SOURCE treatment should match default behavior."""
+        result_default = imf_gdp_deflate(
+            data=eur_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        _registry.default_treatment = "source"
+        result_explicit = imf_gdp_deflate(
+            data=eur_df,
+            base_year=2022,
+            source_currency="EUR",
+            target_currency="EUR",
+        )
+        pd.testing.assert_frame_equal(result_default, result_explicit)

--- a/tests/unit/test_group_registry.py
+++ b/tests/unit/test_group_registry.py
@@ -22,23 +22,30 @@ class TestGroupTreatment:
 
 
 class TestGroupRegistry:
-    def test_eur_registered_by_default(self):
-        assert _registry.is_group("EUR")
+    def test_emu_registered_by_default(self):
+        assert _registry.get("EMU") is not None
 
-    def test_eur_definition(self):
-        group = _registry.get("EUR")
-        assert group is not None
-        assert group.name == "Euro Area (EMU)"
+    def test_emu_definition(self):
+        group = _registry.get("EMU")
+        assert group.key == "EMU"
         assert group.iso3 == "EUR"
+        assert group.name == "Euro Area (EMU)"
 
-    def test_eur_members_callable(self):
-        group = _registry.get("EUR")
+    def test_emu_members_callable(self):
+        group = _registry.get("EMU")
         members = group.get_members(2023)
         assert "HRV" in members
         assert len(members) == 20
 
+    def test_find_by_iso3(self):
+        group = _registry.find_by_iso3("EUR")
+        assert group is not None
+        assert group.key == "EMU"
+
+    def test_find_by_iso3_unknown(self):
+        assert _registry.find_by_iso3("XYZ") is None
+
     def test_unknown_group(self):
-        assert not _registry.is_group("XYZ")
         assert _registry.get("XYZ") is None
 
     def test_default_treatment_is_source(self):
@@ -54,8 +61,8 @@ class TestGroupRegistry:
 
     def test_configure_group(self):
         try:
-            _registry.configure("EUR", treatment="fixed", members_year=2019)
-            config = _registry.get_config("EUR")
+            _registry.configure("EMU", treatment="fixed", members_year=2019)
+            config = _registry.get_config("EMU")
             assert config.treatment == GroupTreatment.FIXED
             assert config.members_year == 2019
         finally:
@@ -66,42 +73,45 @@ class TestGroupRegistry:
             _registry.configure("XYZ", treatment="fixed")
 
     def test_get_config_falls_back_to_default(self):
-        config = _registry.get_config("EUR")
+        config = _registry.get_config("EMU")
         assert config.treatment == _registry.default_treatment
 
     def test_reset_clears_configs(self):
-        _registry.configure("EUR", treatment="dynamic")
+        _registry.configure("EMU", treatment="dynamic")
         _registry.default_treatment = "fixed"
         _registry.reset()
         assert _registry.default_treatment == GroupTreatment.SOURCE
-        config = _registry.get_config("EUR")
+        config = _registry.get_config("EMU")
         assert config.treatment == GroupTreatment.SOURCE
 
     def test_list_groups(self):
         groups = _registry.list_groups()
-        assert "EUR" in groups
+        assert "EMU" in groups
 
     def test_register_custom_group(self):
         try:
             _registry.register(
                 GroupDefinition(
-                    iso3="TEST",
+                    key="TEST",
+                    iso3="TST",
                     name="Test Group",
                     get_members=lambda year: ["AAA", "BBB"],
                 )
             )
-            assert _registry.is_group("TEST")
+            assert _registry.get("TEST") is not None
+            assert _registry.find_by_iso3("TST").key == "TEST"
             group = _registry.get("TEST")
             assert group.get_members(2023) == ["AAA", "BBB"]
         finally:
             _registry._groups.pop("TEST", None)
+            _registry._iso3_to_key.pop("TST", None)
 
     def test_snapshot_and_restore(self):
         state = _registry.snapshot()
-        _registry.configure("EUR", treatment="dynamic", members_year=2019)
+        _registry.configure("EMU", treatment="dynamic", members_year=2019)
         _registry.default_treatment = "fixed"
         assert _registry.default_treatment == GroupTreatment.FIXED
         _registry.restore(state)
         assert _registry.default_treatment == GroupTreatment.SOURCE
-        config = _registry.get_config("EUR")
+        config = _registry.get_config("EMU")
         assert config.members_year is None

--- a/tests/unit/test_group_registry.py
+++ b/tests/unit/test_group_registry.py
@@ -1,0 +1,107 @@
+"""Tests for group registry, types, and configuration."""
+
+import pytest
+
+from pydeflate.groups import (
+    GroupDefinition,
+    GroupTreatment,
+    _registry,
+)
+
+
+class TestGroupTreatment:
+    def test_values(self):
+        assert GroupTreatment.SOURCE == "source"
+        assert GroupTreatment.FIXED == "fixed"
+        assert GroupTreatment.DYNAMIC == "dynamic"
+
+    def test_from_string(self):
+        assert GroupTreatment("source") == GroupTreatment.SOURCE
+        assert GroupTreatment("fixed") == GroupTreatment.FIXED
+        assert GroupTreatment("dynamic") == GroupTreatment.DYNAMIC
+
+
+class TestGroupRegistry:
+    def test_eur_registered_by_default(self):
+        assert _registry.is_group("EUR")
+
+    def test_eur_definition(self):
+        group = _registry.get("EUR")
+        assert group is not None
+        assert group.name == "Euro Area (EMU)"
+        assert group.iso3 == "EUR"
+
+    def test_eur_members_callable(self):
+        group = _registry.get("EUR")
+        members = group.get_members(2023)
+        assert "HRV" in members
+        assert len(members) == 20
+
+    def test_unknown_group(self):
+        assert not _registry.is_group("XYZ")
+        assert _registry.get("XYZ") is None
+
+    def test_default_treatment_is_source(self):
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+
+    def test_set_default_treatment(self):
+        original = _registry.default_treatment
+        try:
+            _registry.default_treatment = "fixed"
+            assert _registry.default_treatment == GroupTreatment.FIXED
+        finally:
+            _registry.default_treatment = original
+
+    def test_configure_group(self):
+        try:
+            _registry.configure("EUR", treatment="fixed", members_year=2019)
+            config = _registry.get_config("EUR")
+            assert config.treatment == GroupTreatment.FIXED
+            assert config.members_year == 2019
+        finally:
+            _registry.reset()
+
+    def test_configure_unknown_group_raises(self):
+        with pytest.raises(ValueError, match="Unknown group"):
+            _registry.configure("XYZ", treatment="fixed")
+
+    def test_get_config_falls_back_to_default(self):
+        config = _registry.get_config("EUR")
+        assert config.treatment == _registry.default_treatment
+
+    def test_reset_clears_configs(self):
+        _registry.configure("EUR", treatment="dynamic")
+        _registry.default_treatment = "fixed"
+        _registry.reset()
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+        config = _registry.get_config("EUR")
+        assert config.treatment == GroupTreatment.SOURCE
+
+    def test_list_groups(self):
+        groups = _registry.list_groups()
+        assert "EUR" in groups
+
+    def test_register_custom_group(self):
+        try:
+            _registry.register(
+                GroupDefinition(
+                    iso3="TEST",
+                    name="Test Group",
+                    get_members=lambda year: ["AAA", "BBB"],
+                )
+            )
+            assert _registry.is_group("TEST")
+            group = _registry.get("TEST")
+            assert group.get_members(2023) == ["AAA", "BBB"]
+        finally:
+            _registry._groups.pop("TEST", None)
+
+    def test_snapshot_and_restore(self):
+        state = _registry.snapshot()
+        _registry.configure("EUR", treatment="dynamic", members_year=2019)
+        _registry.default_treatment = "fixed"
+        assert _registry.default_treatment == GroupTreatment.FIXED
+        _registry.restore(state)
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+        config = _registry.get_config("EUR")
+        assert config.members_year is None

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -1,0 +1,53 @@
+"""Test public API exports for group support."""
+
+import pytest
+
+from pydeflate import (
+    GroupTreatment,
+    configure_group,
+    emu_members,
+    reset_group_config,
+    set_group_treatment,
+)
+from pydeflate.groups import _registry
+
+
+class TestPublicGroupAPI:
+    def test_set_group_treatment(self):
+        set_group_treatment("fixed")
+        assert _registry.default_treatment == GroupTreatment.FIXED
+
+    def test_configure_group(self):
+        configure_group("EUR", treatment="fixed", members_year=2019)
+        config = _registry.get_config("EUR")
+        assert config.treatment == GroupTreatment.FIXED
+        assert config.members_year == 2019
+
+    def test_reset_group_config(self):
+        set_group_treatment("dynamic")
+        configure_group("EUR", treatment="fixed")
+        reset_group_config()
+        assert _registry.default_treatment == GroupTreatment.SOURCE
+
+    def test_configure_unknown_group_raises(self):
+        with pytest.raises(ValueError):
+            configure_group("XYZ", treatment="fixed")
+
+    def test_group_treatment_exported(self):
+        assert GroupTreatment.FIXED == "fixed"
+
+
+class TestEmuMembersPublic:
+    def test_default_returns_all(self):
+        members = emu_members()
+        assert len(members) == 20
+        assert "DEU" in members
+
+    def test_with_year(self):
+        members = emu_members(1999)
+        assert len(members) == 11
+        assert "GRC" not in members
+
+    def test_2023_includes_croatia(self):
+        members = emu_members(2023)
+        assert "HRV" in members

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -18,14 +18,14 @@ class TestPublicGroupAPI:
         assert _registry.default_treatment == GroupTreatment.FIXED
 
     def test_configure_group(self):
-        configure_group("EUR", treatment="fixed", members_year=2019)
-        config = _registry.get_config("EUR")
+        configure_group("EMU", treatment="fixed", members_year=2019)
+        config = _registry.get_config("EMU")
         assert config.treatment == GroupTreatment.FIXED
         assert config.members_year == 2019
 
     def test_reset_group_config(self):
         set_group_treatment("dynamic")
-        configure_group("EUR", treatment="fixed")
+        configure_group("EMU", treatment="fixed")
         reset_group_config()
         assert _registry.default_treatment == GroupTreatment.SOURCE
 


### PR DESCRIPTION
## Summary

Adds configurable GDP-weighted deflator computation for country groups, starting with the Euro Area (EMU). Closes #27.

When deflating EUR-denominated data, pydeflate has historically relied on whatever aggregate the upstream data source (IMF, World Bank, OECD DAC) publishes. This is fine for many use cases, but the methodology behind those aggregates is opaque, inconsistent across sources, and doesn't account for changing eurozone membership over time (e.g., Croatia joining in 2023). Users working in development economics, climate finance, or EU policy analysis need more control.

This PR introduces three treatment modes for country group deflators:

- **`source`** (default) — Use the data source's own published aggregate. Backward-compatible, no behavior change.
- **`fixed`** — GDP-weighted average of member countries' deflators, using all-time membership for every year. Comparable across time, but historically inaccurate for pre-accession years.
- **`dynamic`** — GDP-weighted average using the actual membership in each year. Historically accurate, but creates composition-change artifacts at accession boundaries.

Users can also pin membership to a specific year for counterfactual analysis (e.g., "use 2019 membership for all years").

## Motivation

Issue #27 identified a gap: pydeflate had no way to compute group deflators from member-country data. The discussion proposed two approaches — GDP-weighted averages with fixed or dynamic membership — and a recent comment pointed to [CuCoPy](https://github.com/FZJ-IEK3-VSA/CuCoPy) as a package that claims to handle this.

### How CuCoPy handles EUR

CuCoPy takes a minimal approach: when the currency is `"EUR"`, it switches from standard CPI to the IMF's Harmonized Index of Consumer Prices for the Euro Area. That means it doesn't implement membership tracking, nor GDP weighting, nor user configuration. It treats the Euro Area is a single entity with a single published CPI series.

This works for simple CPI-based conversions but doesn't address the core problem raised in #27:

| Capability | CuCoPy | pydeflate (this PR) |
|---|---|---|
| Data sources | IMF CPI only | IMF, World Bank, OECD DAC |
| Deflator types | CPI only | GDP deflator, CPI, CPI-eop, linked GDP |
| EUR handling | Hardcoded switch to harmonized CPI | Three configurable modes |
| GDP-weighted group averages | No | Yes, with equal-weight fallback |
| Dynamic membership tracking | No | Yes (all 20 members with accession years) |
| Pin membership to a year | No | Yes |
| Extensible to other groups | No | Yes (plugin-friendly `GroupRegistry`) |
| DataFrame batch operations | No (scalar only) | Yes |

### Why not just use the source aggregate?

The source aggregate (`source` mode) is a reasonable default, but it has limitations:

1. **Opaque methodology** — IMF, World Bank, and OECD each compute the Euro Area aggregate differently. Users can't inspect or reproduce the calculation.
2. **Inconsistent membership** — Some sources lag behind membership changes. The IMF may not immediately reflect a new members' accession in its Euro Area aggregate.
3. **No counterfactual analysis** — Researchers often need "what if we used 2015 membership for all years?" to isolate composition effects from price effects.

## Architecture

The implementation adds three new modules:

- **`src/pydeflate/groups/`** — Group registry and EMU membership data
  - `GroupRegistry` — singleton registry of known country groups with per-group configuration
  - `GroupTreatment` enum — `SOURCE`, `FIXED`, `DYNAMIC`
  - `emu.py` — all 20 EMU members with accession years (1999–2023)
- **`src/pydeflate/core/group_deflator.py`** — `compute_group_deflator()` replaces a group's aggregate deflator rows with GDP-weighted member averages
- **Public API** in `__init__.py` — `set_group_treatment()`, `configure_group()`, `reset_group_config()`, `emu_members()`

Groups are identified by a **key** (e.g., `"EMU"`) that is distinct from the currency code (`"EUR"`). This avoids ambiguity: `source_currency="EUR"` refers to the currency, while `configure_group("EMU", ...)` refers to the country grouping. Internally, `_maybe_apply_group_deflator()` resolves the currency ISO3 to the corresponding group via `find_by_iso3()`.  

The group deflator hooks into `BaseDeflate.__init__()` via `_maybe_apply_group_deflator()`, which shallow-copies the source and replaces deflator values before the existing pipeline runs. Exchange rates are never modified — they're market rates, not aggregates.

### Data change

The IMF source pipeline now preserves `NGDPD` (nominal GDP in USD) in the processed DataFrame. This column was previously dropped after computing exchange rates but is now needed as the GDP weight for group deflator computation. Cache version bumped to `"3"`.

## Usage

### Basic: GDP-weighted EUR deflators

```python
import pydeflate

# Use GDP-weighted average of all eurozone members' deflators
pydeflate.set_group_treatment("fixed")

result = pydeflate.imf_gdp_deflate(
    data=df,
    base_year=2015,
    source_currency="EUR",
    target_currency="USD",
)
```

### Per-group configuration with membership pinning

```python
# Use 2019 membership for all years (pre-COVID, pre-Croatia
pydeflate.configure_group("EMU", treatment="fixed", members_year=2019)          

result = pydeflate.imf_gdp_deflate(
    data=df,
    base_year=2015,
    source_currency="EUR",
    target_currency="EUR",
)

# Reset when done
pydeflate.reset_group_config()
```

### Scoped configuration with context manager

```python
from pydeflate import pydeflate_session

with pydeflate_session(group_treatment="dynamic"):
    # Dynamic membership: uses actual members per year
    # (11 members in 1999, 20 members in 2023)
    result = pydeflate.imf_gdp_deflate(
        data=df,
        base_year=2015,
        source_currency="EUR",
        target_currency="EUR",
    )
# Treatment automatically reverts to "source" outside the context
```

### Query EMU membership

```python
>>> pydeflate.emu_members(1999)
['AUT', 'BEL', 'DEU', 'ESP', 'FIN', 'FRA', 'IRL', 'ITA', 'LUX', 'NLD', 'PRT']

>>> pydeflate.emu_members(2023)
['AUT', 'BEL', 'CYP', 'DEU', 'ESP', 'EST', 'FIN', 'FRA', 'GRC', 'HRV',
 'IRL', 'ITA', 'LTU', 'LUX', 'LVA', 'MLT', 'NLD', 'PRT', 'SVK', 'SVN']

>>> pydeflate.emu_members()  # all-time members
# ... all 20 countries
```
