### PR TITLE
Duplicate rows fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/src/pydeflate/utils.py
+++ b/src/pydeflate/utils.py
@@ -106,7 +106,7 @@ def merge_user_and_pydeflate_data(
 
     df_ = data.merge(
         pydeflate_data,
-        how="outer",
+        how="left",
         left_on=["pydeflate_year", f"temp_{entity_column}"],
         right_on=ix,
         suffixes=("", "_pydeflate"),

--- a/tests/integration/test_imf_deflators.py
+++ b/tests/integration/test_imf_deflators.py
@@ -23,7 +23,6 @@ def _base_deflate(
         to_current=to_current,
     )
 
-
 def test_imf_gdp_deflate_returns_constant_prices(sample_source_frames):
     data = pd.DataFrame(
         {
@@ -47,6 +46,7 @@ def test_imf_gdp_deflate_returns_constant_prices(sample_source_frames):
     assert result["value"].tolist() == pytest.approx(
         expected["value"].tolist(), rel=1e-6
     )
+    assert len(result) == len(data)
 
 
 def test_imf_cpi_deflate_to_current_prices(sample_source_frames):
@@ -77,3 +77,4 @@ def test_imf_cpi_deflate_to_current_prices(sample_source_frames):
     assert result["value"].tolist() == pytest.approx(
         expected["value"].tolist(), rel=1e-6
     )
+    assert len(result) == len(data)

--- a/tests/integration/test_world_bank_deflators.py
+++ b/tests/integration/test_world_bank_deflators.py
@@ -49,6 +49,7 @@ def test_wb_gdp_deflate_with_iso_codes(sample_source_frames):
     assert result["value"].tolist() == pytest.approx(
         expected["value"].tolist(), rel=1e-6
     )
+    assert len(result) == len(data)
 
 
 def test_wb_gdp_deflate_accepts_source_codes(sample_source_frames):
@@ -83,6 +84,7 @@ def test_wb_gdp_deflate_accepts_source_codes(sample_source_frames):
     assert result["value"].tolist() == pytest.approx(
         expected["value"].tolist(), rel=1e-6
     )
+    assert len(result) == len(data)
 
 
 def test_wb_cpi_deflate_to_current_prices(sample_source_frames):
@@ -113,6 +115,7 @@ def test_wb_cpi_deflate_to_current_prices(sample_source_frames):
     assert result["value"].tolist() == pytest.approx(
         expected["value"].tolist(), rel=1e-6
     )
+    assert len(result) == len(data)
 
 
 def test_wb_gdp_linked_deflate_uses_linked_series(sample_source_frames):
@@ -138,3 +141,4 @@ def test_wb_gdp_linked_deflate_uses_linked_series(sample_source_frames):
     assert result["value"].tolist() == pytest.approx(
         expected["value"].tolist(), rel=1e-6
     )
+    assert len(result) == len(data)


### PR DESCRIPTION
Fixes #46

- Outer merge changed for 'left' to avoid row duplication
- Small improvement to test strength (check for equal length).

Admittedly the test changes are not my favourite, but for now they should be pragmatic enough.
