### PR TITLE
Bump action-gh-release v2 -> v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
         run: uv publish
 
       - name: Create GitHub Release (draft)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           generate_release_notes: true


### PR DESCRIPTION
The release workflow's `softprops/action-gh-release@v2` runs on Node.js 20, which GitHub Actions runners deprecate from 2026-06-16. Bump to `@v3`, the Node 24 line.

Per the action's v3.0.0 notes, v3 is a **runtime-only** change (Node 20 → 24) with no input or behavior changes. Only `.github/workflows/release.yaml` is touched; no package change, so no version bump.