### PR TITLE
Fix docs build: bump pymdown-extensions for Pygments 2.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ docs = [
     "mkdocs-material>=9.5.0",
     "mkdocs-minify-plugin>=0.8.0",
     "mkdocstrings[python]>=0.26.0",
+    # 10.21.3 fixes a crash with Pygments 2.20.0 (filename=None -> html.escape)
+    "pymdown-extensions>=10.21.3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1074,6 +1074,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pymdown-extensions" },
 ]
 
 [package.metadata]
@@ -1105,6 +1106,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
+    { name = "pymdown-extensions", specifier = ">=10.21.3" },
 ]
 
 [[package]]
@@ -1118,15 +1120,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The v2.6.0 **Deploy Documentation** run failed building `faq.md` with `AttributeError: 'NoneType' object has no attribute 'replace'`.

## Cause
Pygments 2.20.0 changed `HtmlFormatter` to call `html.escape(filename)`, which crashes when pymdown-extensions passes `filename=None`. The docs deps are unpinned, so the release runner pulled pygments 2.20.0 against pymdown-extensions 10.21.

## Fix
Pin `pymdown-extensions>=10.21.3` (its patch handles the `None`), keeping pygments current.

- Verified: `uv run mkdocs build --clean --strict` builds clean (pygments 2.20.0 + pymdownx 10.21.3).
- Docs-only dev dependency — no change to the published wheel.